### PR TITLE
fix: wire metrics middleware, fix event list pagination, fix invite revocation_reason round-trip

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -665,6 +665,7 @@ func main() {
 		CleanupHandler:           cleanupHandler,
 		EmailHealthHandler:       emailHealthHandler,
 		AuthMiddleware:           middlewareAdapter,
+		MetricsMiddleware:        middleware.PrometheusMetrics(metricsCollector),
 		StaticFileServer:         staticFS,
 	})
 

--- a/internal/db/repositories/invite_repository.go
+++ b/internal/db/repositories/invite_repository.go
@@ -196,7 +196,7 @@ func (r *inviteRepository) CreateBatch(ctx context.Context, invites []*models.In
 func (r *inviteRepository) GetByID(ctx context.Context, id int64) (*models.Invite, error) {
 	query := `
 		SELECT id, event_id, name, email, token, token_hash, max_plus_ones, status,
-			sent_at, viewed_at, unsubscribed, email_invalid,
+			sent_at, viewed_at, revocation_reason, unsubscribed, email_invalid,
 			created_at, updated_at, expires_at
 		FROM invites
 		WHERE id = ?
@@ -214,6 +214,7 @@ func (r *inviteRepository) GetByID(ctx context.Context, id int64) (*models.Invit
 		&invite.Status,
 		&invite.SentAt,
 		&invite.ViewedAt,
+		&invite.RevocationReason,
 		&invite.Unsubscribed,
 		&invite.EmailInvalid,
 		&invite.CreatedAt,
@@ -237,7 +238,7 @@ func (r *inviteRepository) GetByID(ctx context.Context, id int64) (*models.Invit
 func (r *inviteRepository) GetByTokenHash(ctx context.Context, tokenHash string) (*models.Invite, error) {
 	query := `
 		SELECT id, event_id, name, email, token, token_hash, max_plus_ones, status,
-			sent_at, viewed_at, unsubscribed, email_invalid,
+			sent_at, viewed_at, revocation_reason, unsubscribed, email_invalid,
 			created_at, updated_at, expires_at
 		FROM invites
 		WHERE token_hash = ?
@@ -255,6 +256,7 @@ func (r *inviteRepository) GetByTokenHash(ctx context.Context, tokenHash string)
 		&invite.Status,
 		&invite.SentAt,
 		&invite.ViewedAt,
+		&invite.RevocationReason,
 		&invite.Unsubscribed,
 		&invite.EmailInvalid,
 		&invite.CreatedAt,
@@ -610,7 +612,7 @@ func (r *inviteRepository) GetByEventIDs(ctx context.Context, eventIDs []int64) 
 
 	query := fmt.Sprintf(`
 		SELECT id, event_id, name, email, token, token_hash, max_plus_ones, status,
-			sent_at, viewed_at, unsubscribed, email_invalid,
+			sent_at, viewed_at, revocation_reason, unsubscribed, email_invalid,
 			created_at, updated_at, expires_at
 		FROM invites
 		WHERE event_id IN (%s)
@@ -637,6 +639,7 @@ func (r *inviteRepository) GetByEventIDs(ctx context.Context, eventIDs []int64) 
 			&invite.Status,
 			&invite.SentAt,
 			&invite.ViewedAt,
+			&invite.RevocationReason,
 			&invite.Unsubscribed,
 			&invite.EmailInvalid,
 			&invite.CreatedAt,

--- a/internal/db/repositories/invite_repository_test.go
+++ b/internal/db/repositories/invite_repository_test.go
@@ -545,6 +545,61 @@ func TestInviteRepository_Update(t *testing.T) {
 	}
 }
 
+func TestInviteRepository_RevocationReasonRoundTrip(t *testing.T) {
+	database := setupInviteTestDB(t)
+	defer database.Close()
+
+	repo := NewInviteRepository(database)
+
+	email := "revoke@example.com"
+	invite := &models.Invite{
+		EventID:     1,
+		Email:       &email,
+		TokenHash:   strings.Repeat("b", 43),
+		MaxPlusOnes: 1,
+		Status:      models.InviteStatusSent,
+		ExpiresAt:   time.Now().Add(30 * 24 * time.Hour),
+	}
+
+	if err := repo.Create(context.Background(), invite); err != nil {
+		t.Fatalf("Failed to create invite: %v", err)
+	}
+
+	reason := "User requested cancellation"
+	invite.Status = models.InviteStatusRevoked
+	invite.RevocationReason = &reason
+
+	if err := repo.Update(context.Background(), invite); err != nil {
+		t.Fatalf("Failed to revoke invite: %v", err)
+	}
+
+	retrieved, err := repo.GetByID(context.Background(), invite.ID)
+	if err != nil {
+		t.Fatalf("Failed to retrieve revoked invite: %v", err)
+	}
+
+	if retrieved.Status != models.InviteStatusRevoked {
+		t.Errorf("Status = %s, want %s", retrieved.Status, models.InviteStatusRevoked)
+	}
+
+	if retrieved.RevocationReason == nil {
+		t.Fatal("RevocationReason is nil after read-back; SELECT must include revocation_reason")
+	}
+
+	if *retrieved.RevocationReason != reason {
+		t.Errorf("RevocationReason = %q, want %q", *retrieved.RevocationReason, reason)
+	}
+
+	retrievedByHash, err := repo.GetByTokenHash(context.Background(), invite.TokenHash)
+	if err != nil {
+		t.Fatalf("Failed to retrieve by token hash: %v", err)
+	}
+
+	if retrievedByHash.RevocationReason == nil || *retrievedByHash.RevocationReason != reason {
+		t.Errorf("GetByTokenHash RevocationReason = %v, want %q", retrievedByHash.RevocationReason, reason)
+	}
+}
+
 func TestInviteRepository_Delete(t *testing.T) {
 	database := setupInviteTestDB(t)
 	defer database.Close()

--- a/internal/handlers/events_web.go
+++ b/internal/handlers/events_web.go
@@ -32,6 +32,7 @@ type EventListPageData struct {
 	Events     []*models.Event
 	Total      int
 	Page       int
+	PageSize   int
 	Filter     string
 	Sort       string
 	Error      string
@@ -122,6 +123,7 @@ func (h *EventWebHandlers) ListEventsPage(w http.ResponseWriter, r *http.Request
 		Events:     eventList,
 		Total:      len(eventList),
 		Page:       page,
+		PageSize:   limit,
 		Filter:     r.URL.Query().Get("status"),
 		Sort:       r.URL.Query().Get("sort"),
 	}

--- a/internal/handlers/router.go
+++ b/internal/handlers/router.go
@@ -71,6 +71,8 @@ type RouterHandlers struct {
 
 	AuthMiddleware AuthMiddlewareInterface
 
+	MetricsMiddleware func(http.Handler) http.Handler
+
 	StaticFileServer http.Handler
 
 	Logger *log.Logger
@@ -246,6 +248,10 @@ func NewRouter(handlers *RouterHandlers) *Router {
 			AdminLimit:         3000,
 		})(next)
 	})
+
+	if handlers.MetricsMiddleware != nil {
+		r.Use(handlers.MetricsMiddleware)
+	}
 
 	r.NotFound(NotFoundHandler)
 	r.MethodNotAllowed(MethodNotAllowedHandler)

--- a/templates/web/event_list.html
+++ b/templates/web/event_list.html
@@ -116,7 +116,7 @@
         {{end}}
     </section>
 
-    {{if gt .Total 10}}
+    {{if and (gt .Total 0) (gt .Total .PageSize)}}
     <nav class="event-pagination" aria-label="Pagination">
         <ul class="pagination">
             {{if gt .Page 1}}
@@ -132,7 +132,7 @@
             {{end}}
 
             {{$currentPage := .Page}}
-            {{$totalPages := div (add .Total 9) 10}}
+            {{$totalPages := div (add .Total (sub .PageSize 1)) .PageSize}}
             
             {{range $i := until $totalPages}}
             {{$pageNum := add $i 1}}

--- a/templates/web/event_list_test.go
+++ b/templates/web/event_list_test.go
@@ -27,6 +27,7 @@ type EventListData struct {
 	Sort    string
 	Page    int
 	Total   int
+	PageSize int
 }
 
 func getEventListTemplate() (*template.Template, error) {
@@ -364,8 +365,9 @@ func TestEventListTemplatePagination(t *testing.T) {
 		Events: []EventListEvent{
 			{ID: 1, Title: "Event 1"},
 		},
-		Page:  2,
-		Total: 50,
+		Page:     2,
+		Total:    50,
+		PageSize: 10,
 	}
 
 	var buf strings.Builder


### PR DESCRIPTION
## Summary

Three pre-existing bugs found during the architecture review for Epic 10 features. Each is a real defect independent of the feature work.

## Bug 1: Metrics middleware never applied (Critical)

`PrometheusMetrics()` was defined (`middleware/metrics.go:59`) and `metricsCollector` was created (`main.go:277`), but the middleware was **never threaded into `NewRouter`'s chain** (`router.go:213-248` applies Recovery, RequestID, RealIP, Logging, Timeout, SecurityHeaders, CSRF, RateLimit — but not PrometheusMetrics).

**Consequence**: `/metrics` scraped successfully but `http_requests_total` and `http_request_duration_seconds` were **always zero**. Anyone scraping this endpoint in production is getting useless data.

**Fix**: Added `MetricsMiddleware func(http.Handler) http.Handler` field to `RouterHandlers`, applied it after rate limiting in `NewRouter`, wired it in `main.go`.

## Bug 2: Event list pagination constant mismatch

The template computed total pages as `div (add .Total 9) 10` (`event_list.html:135`) — hardcoded page size 10. The handler uses `limit := 50` (`events_web.go:87`). With 25 events, the template would show 3 page links but only 1 page of 50 exists.

**Fix**: Added `PageSize int` to `EventListPageData`, set it from the handler's limit, used it in the template's ceiling-division formula `(Total + PageSize - 1) / PageSize` and the pagination visibility condition `.Total > .PageSize`.

## Bug 3: Invite revocation_reason not read back (Data integrity)

The `Update` method writes `revocation_reason` (`invite_repository.go:286`), but all three SELECT queries (`GetByID`, `GetByTokenHash`, `GetByEventIDs`) omitted the column. The `Revoke` service method (`invites/service.go:361`) sets the reason in memory before calling `Update`, so it persists — but reading the invite back returns `RevocationReason = nil`. A subsequent `Update` on that invite would write `NULL` back, **clobbering the saved reason**.

**Fix**: Added `revocation_reason` to all three SELECT column lists and their Scan calls. Added integration test (`TestInviteRepository_RevocationReasonRoundTrip`) verifying the full create → revoke → read-back cycle.

## Validation
- `go vet ./...` — clean
- `go build ./...` — clean
- Full test suite (excluding UX) — all pass
- New test `TestInviteRepository_RevocationReasonRoundTrip` — pass