### PR TITLE
feat: event list stats display with invite/RSVP/accept counts (10-07)

### DIFF
--- a/docs/01_WORKLOG/0160_2026-07-07_event_list_stats.md
+++ b/docs/01_WORKLOG/0160_2026-07-07_event_list_stats.md
@@ -1,0 +1,70 @@
+# Worklog 0160: Event List Stats Display (Epic 10 Story 07)
+
+**Date:** 2026-07-07  
+**Epic:** 10 (Technical Debt)  
+**Story:** [10_STORY_07_event_list_stats.md](../00_BACKLOG/10_TECHNICAL_DEBT/10_STORY_07_event_list_stats.md)  
+**Branch:** `feat/event-list-stats-10-07`  
+**PR:** #31
+
+---
+
+## Summary
+
+Added per-event statistics (invite count, RSVP count, accept count) to the event list page. Stats are computed in a single aggregated SQL query using LEFT JOINs and GROUP BY, matching the existing `InviteRepository.GetStats` pattern. No N+1 queries.
+
+## Approach
+
+### Data flow
+
+```
+EventRepository.ListWithStats (LEFT JOIN + GROUP BY)
+  → events.Service.ListEventsWithStats (same authz as ListEvents)
+    → EventWebHandlers.ListEventsPage
+      → event_list.html (stats row per card)
+```
+
+### SQL
+
+```sql
+SELECT e.*,
+    COUNT(DISTINCT i.id) AS invite_count,
+    COUNT(DISTINCT r.id) AS rsvp_count,
+    COUNT(DISTINCT CASE WHEN r.response = 'yes' THEN r.id END) AS accept_count
+FROM events e
+LEFT JOIN invites i ON e.id = i.event_id AND i.status != 'revoked'
+LEFT JOIN rsvps r ON i.id = r.invite_id
+WHERE ... GROUP BY e.id
+```
+
+`COUNT(DISTINCT)` prevents Cartesian product inflation when an event has multiple invites AND each invite has multiple RSVPs.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `internal/models/event.go` | `EventWithStats` struct (embeds `Event` value + 3 count fields) |
+| `internal/db/repositories/event_repository.go` | `ListWithStats` method + interface addition |
+| `internal/events/service.go` | `ListEventsWithStats` on `Service` interface + implementation |
+| `internal/handlers/events_web.go` | `ListEventsPage` calls `ListEventsWithStats`; `EventListPageData.Events` → `[]*models.EventWithStats` |
+| `templates/web/event_list.html` | Stats row with invite/RSVP/accept counts |
+| Generated mocks | `MockEventRepository`, `MockEventService` regenerated |
+| Local test mocks | 6 func-field mocks across events/handlers/invites packages updated with `ListWithStats` stubs |
+
+## Tests
+
+- `TestEventRepository_ListWithStats`: creates 2 events (one with 3 invites/2 RSVPs, one empty), verifies counts (2 non-revoked invites, 2 RSVPs, 1 accept), verifies filter support, verifies empty event shows zero stats
+- Updated `TestEventWebHandlers_ListEventsPage` to mock `ListEventsWithStats`
+
+## Design decisions
+
+- **Non-revoked invites only**: `i.status != 'revoked'` in the JOIN condition
+- **EventWithStats embeds Event by value** (not pointer): avoids nil-dereference risk
+- **Placed in `models/`**: accessible to all layers, follows the story spec
+- **Regenerated both mock types**: gomock-generated (`MockEventRepository`, `MockEventService`) and local func-field mocks
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** Full suite green (excluding UX)  
+**Confidence:** HIGH  
+**Production Ready:** Yes — pending PR review approval

--- a/internal/db/repositories/event_repository.go
+++ b/internal/db/repositories/event_repository.go
@@ -23,6 +23,7 @@ type EventRepository interface {
 	UpdateStatus(ctx context.Context, id int64, status models.EventStatus) error
 	Delete(ctx context.Context, id int64) error
 	List(ctx context.Context, filters ListFilters) ([]*models.Event, error)
+	ListWithStats(ctx context.Context, filters ListFilters) ([]*models.EventWithStats, error)
 	GetByStatus(ctx context.Context, status models.EventStatus) ([]*models.Event, error)
 	GetEventsToArchive(ctx context.Context, daysAfterEvent int) ([]*models.Event, error)
 	GetByCreatorID(ctx context.Context, creatorID int64) ([]*models.Event, error)
@@ -529,6 +530,103 @@ func (r *eventRepository) List(ctx context.Context, filters ListFilters) ([]*mod
 	}
 
 	return events, nil
+}
+
+func (r *eventRepository) ListWithStats(ctx context.Context, filters ListFilters) ([]*models.EventWithStats, error) {
+	baseSelect := `
+		e.id, e.public_id, e.friendly_name, e.title, e.description, e.start_time, e.end_time, e.timezone, e.location,
+		e.status, e.created_by, e.version, e.ics_sequence, e.max_plus_ones, e.rsvp_deadline,
+		e.allow_rsvp_after_deadline, e.allow_maybe_rsvp, e.private_guest_list, e.family_headcount, e.event_capacity,
+		e.template_id, e.custom_theme_image_url, e.custom_theme_color, e.component_overrides,
+		e.created_at, e.updated_at`
+
+	query := fmt.Sprintf(`
+		SELECT %s,
+			COUNT(DISTINCT i.id) AS invite_count,
+			COUNT(DISTINCT r.id) AS rsvp_count,
+			COUNT(DISTINCT CASE WHEN r.response = 'yes' THEN r.id END) AS accept_count
+		FROM events e
+		LEFT JOIN invites i ON e.id = i.event_id AND i.status != 'revoked'
+		LEFT JOIN rsvps r ON i.id = r.invite_id
+		WHERE 1=1
+	`, baseSelect)
+
+	args := []interface{}{}
+
+	if filters.CreatorID != nil {
+		query += " AND e.created_by = ?"
+		args = append(args, *filters.CreatorID)
+	}
+
+	if filters.Status != nil {
+		query += " AND e.status = ?"
+		args = append(args, *filters.Status)
+	}
+
+	query += " GROUP BY e.id"
+	query += " ORDER BY e.start_time DESC"
+
+	if filters.Limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, filters.Limit)
+	}
+
+	if filters.Offset > 0 {
+		query += " OFFSET ?"
+		args = append(args, filters.Offset)
+	}
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list events with stats: %w", err)
+	}
+	defer rows.Close()
+
+	var results []*models.EventWithStats
+	for rows.Next() {
+		ews := &models.EventWithStats{}
+		err := rows.Scan(
+			&ews.ID,
+			&ews.PublicID,
+			&ews.FriendlyName,
+			&ews.Title,
+			&ews.Description,
+			&ews.StartTime,
+			&ews.EndTime,
+			&ews.Timezone,
+			&ews.Location,
+			&ews.Status,
+			&ews.CreatedBy,
+			&ews.Version,
+			&ews.ICSSequence,
+			&ews.MaxPlusOnes,
+			&ews.RSVPDeadline,
+			&ews.AllowRSVPAfterDeadline,
+			&ews.AllowMaybeRSVP,
+			&ews.PrivateGuestList,
+			&ews.FamilyHeadcount,
+			&ews.EventCapacity,
+			&ews.TemplateID,
+			&ews.CustomThemeImageURL,
+			&ews.CustomThemeColor,
+			&ews.ComponentOverrides,
+			&ews.CreatedAt,
+			&ews.UpdatedAt,
+			&ews.InviteCount,
+			&ews.RSVPCount,
+			&ews.AcceptCount,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan event with stats: %w", err)
+		}
+		results = append(results, ews)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating events with stats: %w", err)
+	}
+
+	return results, nil
 }
 
 func (r *eventRepository) GetByStatus(ctx context.Context, status models.EventStatus) ([]*models.Event, error) {

--- a/internal/db/repositories/event_repository_test.go
+++ b/internal/db/repositories/event_repository_test.go
@@ -1362,3 +1362,115 @@ func TestEventRepository_CountEvents_Empty(t *testing.T) {
 		t.Errorf("CountEvents() = %d, want 0", count)
 	}
 }
+
+func TestEventRepository_ListWithStats(t *testing.T) {
+	database := setupEventTestDB(t)
+	defer database.Close()
+
+	repo := NewEventRepository(database)
+	ctx := context.Background()
+
+	event := &models.Event{
+		Title:       "Stats Event",
+		StartTime:   time.Now().Add(24 * time.Hour),
+		Timezone:    "America/Los_Angeles",
+		Status:      models.EventStatusPublished,
+		CreatedBy:   1,
+		MaxPlusOnes: 0,
+	}
+	if err := repo.Create(ctx, event); err != nil {
+		t.Fatalf("Failed to create event: %v", err)
+	}
+
+	emptyEvent := &models.Event{
+		Title:       "Empty Event",
+		StartTime:   time.Now().Add(48 * time.Hour),
+		Timezone:    "America/Los_Angeles",
+		Status:      models.EventStatusDraft,
+		CreatedBy:   1,
+		MaxPlusOnes: 0,
+	}
+	if err := repo.Create(ctx, emptyEvent); err != nil {
+		t.Fatalf("Failed to create empty event: %v", err)
+	}
+
+	_, err := database.Exec(ctx, `
+		INSERT INTO invites (event_id, email, token, token_hash, max_plus_ones, status, created_at, updated_at, expires_at)
+		VALUES
+		  (?, 'alice@example.com', 'tok1', 'hash1', 0, 'sent', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + 86400),
+		  (?, 'bob@example.com',   'tok2', 'hash2', 0, 'sent', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + 86400),
+		  (?, 'carol@example.com', 'tok3', 'hash3', 0, 'revoked', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + 86400)
+	`, event.ID, event.ID, event.ID)
+	if err != nil {
+		t.Fatalf("Failed to create invites: %v", err)
+	}
+
+	_, err = database.Exec(ctx, `
+		INSERT INTO rsvps (invite_id, response, plus_ones, created_at, updated_at)
+		VALUES
+		  (1, 'yes',    0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		  (2, 'no',     0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to create rsvps: %v", err)
+	}
+
+	results, err := repo.ListWithStats(ctx, ListFilters{})
+	if err != nil {
+		t.Fatalf("ListWithStats failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 events with stats, got %d", len(results))
+	}
+
+	var statsEvent, emptyStatsEvent *models.EventWithStats
+	for _, r := range results {
+		if r.ID == event.ID {
+			statsEvent = r
+		}
+		if r.ID == emptyEvent.ID {
+			emptyStatsEvent = r
+		}
+	}
+
+	if statsEvent == nil {
+		t.Fatal("Stats event not found in results")
+	}
+
+	if statsEvent.InviteCount != 2 {
+		t.Errorf("InviteCount = %d, want 2 (3 invites - 1 revoked)", statsEvent.InviteCount)
+	}
+
+	if statsEvent.RSVPCount != 2 {
+		t.Errorf("RSVPCount = %d, want 2", statsEvent.RSVPCount)
+	}
+
+	if statsEvent.AcceptCount != 1 {
+		t.Errorf("AcceptCount = %d, want 1 (only 1 'yes' response)", statsEvent.AcceptCount)
+	}
+
+	if statsEvent.Title != event.Title {
+		t.Errorf("Embedded event data wrong: Title = %q, want %q", statsEvent.Title, event.Title)
+	}
+
+	if emptyStatsEvent == nil {
+		t.Fatal("Empty stats event not found in results")
+	}
+
+	if emptyStatsEvent.InviteCount != 0 || emptyStatsEvent.RSVPCount != 0 || emptyStatsEvent.AcceptCount != 0 {
+		t.Errorf("Empty event stats should be zero: invites=%d rsvps=%d accepts=%d",
+			emptyStatsEvent.InviteCount, emptyStatsEvent.RSVPCount, emptyStatsEvent.AcceptCount)
+	}
+
+	filtered, err := repo.ListWithStats(ctx, ListFilters{
+		Status: statusPtr(models.EventStatusPublished),
+	})
+	if err != nil {
+		t.Fatalf("ListWithStats with filter failed: %v", err)
+	}
+
+	if len(filtered) != 1 {
+		t.Errorf("Status filter: expected 1 event, got %d", len(filtered))
+	}
+}

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -16,6 +16,7 @@ type Service interface {
 	UpdateEvent(ctx context.Context, event *models.Event) error
 	DeleteEvent(ctx context.Context, id int64) error
 	ListEvents(ctx context.Context, filters ListFilters) ([]*models.Event, error)
+	ListEventsWithStats(ctx context.Context, filters ListFilters) ([]*models.EventWithStats, error)
 	PublishEvent(ctx context.Context, id int64) error
 	CancelEvent(ctx context.Context, id int64, reason string) error
 	ArchiveEvent(ctx context.Context, id int64) error
@@ -222,6 +223,36 @@ func (s *service) ListEvents(ctx context.Context, filters ListFilters) ([]*model
 	}
 
 	return events, nil
+}
+
+func (s *service) ListEventsWithStats(ctx context.Context, filters ListFilters) ([]*models.EventWithStats, error) {
+	user, ok := auth.UserFromContext(ctx)
+	if !ok {
+		return nil, &models.PermissionDeniedError{
+			Action:   "list events",
+			Resource: "Event",
+		}
+	}
+
+	if !s.authz.IsEventManager(user) {
+		return nil, &models.PermissionDeniedError{
+			Action:   "list events",
+			Resource: "Event",
+		}
+	}
+
+	repoFilters := repositories.ListFilters{
+		CreatorID: filters.CreatorID,
+		Status:    filters.Status,
+		Limit:     filters.Limit,
+		Offset:    filters.Offset,
+	}
+
+	if !s.authz.IsAdmin(user) {
+		repoFilters.CreatorID = &user.ID
+	}
+
+	return s.repo.ListWithStats(ctx, repoFilters)
 }
 
 func (s *service) PublishEvent(ctx context.Context, id int64) error {

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -92,6 +92,10 @@ func (m *mockEventRepository) List(ctx context.Context, filters repositories.Lis
 	return nil, nil
 }
 
+func (m *mockEventRepository) ListWithStats(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error) {
+	return nil, nil
+}
+
 func (m *mockEventRepository) GetByStatus(ctx context.Context, status models.EventStatus) ([]*models.Event, error) {
 	if m.GetByStatusFunc != nil {
 		return m.GetByStatusFunc(ctx, status)

--- a/internal/handlers/events_test.go
+++ b/internal/handlers/events_test.go
@@ -17,15 +17,16 @@ import (
 )
 
 type mockEventService struct {
-	CreateEventFunc        func(ctx context.Context, event *models.Event) error
-	GetEventFunc           func(ctx context.Context, id int64) (*models.Event, error)
-	UpdateEventFunc        func(ctx context.Context, event *models.Event) error
-	DeleteEventFunc        func(ctx context.Context, id int64) error
-	ListEventsFunc         func(ctx context.Context, filters events.ListFilters) ([]*models.Event, error)
-	PublishEventFunc       func(ctx context.Context, id int64) error
-	CancelEventFunc        func(ctx context.Context, id int64, reason string) error
-	ArchiveEventFunc       func(ctx context.Context, id int64) error
-	GetEventsToArchiveFunc func(ctx context.Context, daysAfterEvent int) ([]*models.Event, error)
+	CreateEventFunc           func(ctx context.Context, event *models.Event) error
+	GetEventFunc              func(ctx context.Context, id int64) (*models.Event, error)
+	UpdateEventFunc           func(ctx context.Context, event *models.Event) error
+	DeleteEventFunc           func(ctx context.Context, id int64) error
+	ListEventsFunc            func(ctx context.Context, filters events.ListFilters) ([]*models.Event, error)
+	ListEventsWithStatsFunc   func(ctx context.Context, filters events.ListFilters) ([]*models.EventWithStats, error)
+	PublishEventFunc          func(ctx context.Context, id int64) error
+	CancelEventFunc           func(ctx context.Context, id int64, reason string) error
+	ArchiveEventFunc          func(ctx context.Context, id int64) error
+	GetEventsToArchiveFunc    func(ctx context.Context, daysAfterEvent int) ([]*models.Event, error)
 }
 
 func (m *mockEventService) CreateEvent(ctx context.Context, event *models.Event) error {
@@ -59,6 +60,13 @@ func (m *mockEventService) DeleteEvent(ctx context.Context, id int64) error {
 func (m *mockEventService) ListEvents(ctx context.Context, filters events.ListFilters) ([]*models.Event, error) {
 	if m.ListEventsFunc != nil {
 		return m.ListEventsFunc(ctx, filters)
+	}
+	return nil, nil
+}
+
+func (m *mockEventService) ListEventsWithStats(ctx context.Context, filters events.ListFilters) ([]*models.EventWithStats, error) {
+	if m.ListEventsWithStatsFunc != nil {
+		return m.ListEventsWithStatsFunc(ctx, filters)
 	}
 	return nil, nil
 }

--- a/internal/handlers/events_web.go
+++ b/internal/handlers/events_web.go
@@ -29,9 +29,10 @@ type EventWebHandlers struct {
 
 type EventListPageData struct {
 	ActivePage string
-	Events     []*models.Event
+	Events     []*models.EventWithStats
 	Total      int
 	Page       int
+	PageSize   int
 	Filter     string
 	Sort       string
 	Error      string
@@ -108,7 +109,7 @@ func (h *EventWebHandlers) ListEventsPage(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	eventList, err := h.service.ListEvents(r.Context(), filters)
+	eventList, err := h.service.ListEventsWithStats(r.Context(), filters)
 	if err != nil {
 		h.renderListPage(w, http.StatusOK, &EventListPageData{
 			ActivePage: "events",

--- a/internal/handlers/events_web_test.go
+++ b/internal/handlers/events_web_test.go
@@ -60,10 +60,11 @@ func TestEventWebHandlers_ListEventsPage(t *testing.T) {
 				ID:   1,
 				Role: models.RoleEventManager,
 			},
-			setupMock: func(m *mockEventService) {
-				m.ListEventsFunc = func(ctx context.Context, filters events.ListFilters) ([]*models.Event, error) {
-					return []*models.Event{
-						{
+		setupMock: func(m *mockEventService) {
+			m.ListEventsWithStatsFunc = func(ctx context.Context, filters events.ListFilters) ([]*models.EventWithStats, error) {
+				return []*models.EventWithStats{
+					{
+						Event: models.Event{
 							ID:        1,
 							Title:     "Test Event",
 							StartTime: time.Date(2026, 6, 15, 14, 0, 0, 0, time.UTC),
@@ -74,42 +75,46 @@ func TestEventWebHandlers_ListEventsPage(t *testing.T) {
 							CreatedAt: time.Now(),
 							UpdatedAt: time.Now(),
 						},
-					}, nil
-				}
-			},
-			wantStatus: http.StatusOK,
-			wantBody:   "Test Event",
+						InviteCount: 5,
+						RSVPCount:   3,
+						AcceptCount: 2,
+					},
+				}, nil
+			}
 		},
-		{
-			name:  "list events page empty",
-			query: "",
-			user: &models.User{
-				ID:   1,
-				Role: models.RoleEventManager,
-			},
-			setupMock: func(m *mockEventService) {
-				m.ListEventsFunc = func(ctx context.Context, filters events.ListFilters) ([]*models.Event, error) {
-					return []*models.Event{}, nil
-				}
-			},
-			wantStatus: http.StatusOK,
-			wantBody:   "No Events Found",
+		wantStatus: http.StatusOK,
+		wantBody:   "Test Event",
+	},
+	{
+		name:  "list events page empty",
+		query: "",
+		user: &models.User{
+			ID:   1,
+			Role: models.RoleEventManager,
 		},
-		{
-			name:  "list events with status filter",
-			query: "?status=published",
-			user: &models.User{
-				ID:   1,
-				Role: models.RoleEventManager,
-			},
-			setupMock: func(m *mockEventService) {
-				m.ListEventsFunc = func(ctx context.Context, filters events.ListFilters) ([]*models.Event, error) {
-					if filters.Status == nil || *filters.Status != models.EventStatusPublished {
-						t.Error("Expected published status filter")
-					}
-					return []*models.Event{}, nil
+		setupMock: func(m *mockEventService) {
+			m.ListEventsWithStatsFunc = func(ctx context.Context, filters events.ListFilters) ([]*models.EventWithStats, error) {
+				return []*models.EventWithStats{}, nil
+			}
+		},
+		wantStatus: http.StatusOK,
+		wantBody:   "No Events Found",
+	},
+	{
+		name:  "list events with status filter",
+		query: "?status=published",
+		user: &models.User{
+			ID:   1,
+			Role: models.RoleEventManager,
+		},
+		setupMock: func(m *mockEventService) {
+			m.ListEventsWithStatsFunc = func(ctx context.Context, filters events.ListFilters) ([]*models.EventWithStats, error) {
+				if filters.Status == nil || *filters.Status != models.EventStatusPublished {
+					t.Error("Expected published status filter")
 				}
-			},
+				return []*models.EventWithStats{}, nil
+			}
+		},
 			wantStatus: http.StatusOK,
 		},
 		{

--- a/internal/handlers/invites_import_permission_test.go
+++ b/internal/handlers/invites_import_permission_test.go
@@ -53,6 +53,10 @@ func (m *mockEventRepository) List(ctx context.Context, filters repositories.Lis
 	return nil, nil
 }
 
+func (m *mockEventRepository) ListWithStats(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error) {
+	return nil, nil
+}
+
 func (m *mockEventRepository) GetByStatus(ctx context.Context, status models.EventStatus) ([]*models.Event, error) {
 	return nil, nil
 }

--- a/internal/handlers/invites_regenerate_test.go
+++ b/internal/handlers/invites_regenerate_test.go
@@ -135,6 +135,10 @@ func (m *mockRegenerateEventRepository) List(ctx context.Context, filters reposi
 	return []*models.Event{}, nil
 }
 
+func (m *mockRegenerateEventRepository) ListWithStats(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error) {
+	return nil, nil
+}
+
 func (m *mockRegenerateEventRepository) GetByCreatorID(ctx context.Context, creatorID int64) ([]*models.Event, error) {
 	return []*models.Event{}, nil
 }

--- a/internal/handlers/invites_revoke_test.go
+++ b/internal/handlers/invites_revoke_test.go
@@ -136,6 +136,10 @@ func (m *mockRevokeEventRepository) List(ctx context.Context, filters repositori
 	return []*models.Event{}, nil
 }
 
+func (m *mockRevokeEventRepository) ListWithStats(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error) {
+	return nil, nil
+}
+
 func (m *mockRevokeEventRepository) GetByCreatorID(ctx context.Context, creatorID int64) ([]*models.Event, error) {
 	return []*models.Event{}, nil
 }

--- a/internal/handlers/rsvp_mocks_test.go
+++ b/internal/handlers/rsvp_mocks_test.go
@@ -77,6 +77,10 @@ func (m *mockRSVPEventRepository) List(ctx context.Context, filters repositories
 	return nil, nil
 }
 
+func (m *mockRSVPEventRepository) ListWithStats(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error) {
+	return nil, nil
+}
+
 func (m *mockRSVPEventRepository) GetByStatus(ctx context.Context, status models.EventStatus) ([]*models.Event, error) {
 	return nil, nil
 }

--- a/internal/invites/service_individual_test.go
+++ b/internal/invites/service_individual_test.go
@@ -46,6 +46,10 @@ func (m *mockEventRepository) List(ctx context.Context, filters repositories.Lis
 	return nil, nil
 }
 
+func (m *mockEventRepository) ListWithStats(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error) {
+	return nil, nil
+}
+
 func (m *mockEventRepository) GetByStatus(ctx context.Context, status models.EventStatus) ([]*models.Event, error) {
 	return nil, nil
 }

--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -39,3 +39,10 @@ type Event struct {
 	CreatedAt              time.Time   `db:"created_at" json:"created_at"`
 	UpdatedAt              time.Time   `db:"updated_at" json:"updated_at"`
 }
+
+type EventWithStats struct {
+	Event
+	InviteCount int `db:"invite_count" json:"invite_count"`
+	RSVPCount   int `db:"rsvp_count" json:"rsvp_count"`
+	AcceptCount int `db:"accept_count" json:"accept_count"`
+}

--- a/internal/testutil/mocks/repositories/mock_event_repository.go
+++ b/internal/testutil/mocks/repositories/mock_event_repository.go
@@ -219,6 +219,21 @@ func (mr *MockEventRepositoryMockRecorder) List(ctx, filters any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockEventRepository)(nil).List), ctx, filters)
 }
 
+// ListWithStats mocks base method.
+func (m *MockEventRepository) ListWithStats(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWithStats", ctx, filters)
+	ret0, _ := ret[0].([]*models.EventWithStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWithStats indicates an expected call of ListWithStats.
+func (mr *MockEventRepositoryMockRecorder) ListWithStats(ctx, filters any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWithStats", reflect.TypeOf((*MockEventRepository)(nil).ListWithStats), ctx, filters)
+}
+
 // Update mocks base method.
 func (m *MockEventRepository) Update(ctx context.Context, event *models.Event) error {
 	m.ctrl.T.Helper()

--- a/internal/testutil/mocks/services/mock_event_service.go
+++ b/internal/testutil/mocks/services/mock_event_service.go
@@ -143,6 +143,21 @@ func (mr *MockEventServiceMockRecorder) ListEvents(ctx, filters any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvents", reflect.TypeOf((*MockEventService)(nil).ListEvents), ctx, filters)
 }
 
+// ListEventsWithStats mocks base method.
+func (m *MockEventService) ListEventsWithStats(ctx context.Context, filters events.ListFilters) ([]*models.EventWithStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEventsWithStats", ctx, filters)
+	ret0, _ := ret[0].([]*models.EventWithStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEventsWithStats indicates an expected call of ListEventsWithStats.
+func (mr *MockEventServiceMockRecorder) ListEventsWithStats(ctx, filters any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEventsWithStats", reflect.TypeOf((*MockEventService)(nil).ListEventsWithStats), ctx, filters)
+}
+
 // PublishEvent mocks base method.
 func (m *MockEventService) PublishEvent(ctx context.Context, id int64) error {
 	m.ctrl.T.Helper()

--- a/templates/web/event_list.html
+++ b/templates/web/event_list.html
@@ -104,6 +104,24 @@
                         </time>
                     </div>
                 </div>
+
+                <div class="event-card-stats" role="list">
+                    <span class="event-card-stat" role="listitem">
+                        <span class="event-card-meta-icon" aria-hidden="true">✉️</span>
+                        <span class="event-card-stat-value">{{.InviteCount}}</span>
+                        <span>Invites</span>
+                    </span>
+                    <span class="event-card-stat" role="listitem">
+                        <span class="event-card-meta-icon" aria-hidden="true">📝</span>
+                        <span class="event-card-stat-value">{{.RSVPCount}}</span>
+                        <span>RSVPs</span>
+                    </span>
+                    <span class="event-card-stat" role="listitem">
+                        <span class="event-card-meta-icon" aria-hidden="true">✅</span>
+                        <span class="event-card-stat-value">{{.AcceptCount}}</span>
+                        <span>Accepted</span>
+                    </span>
+                </div>
             </div>
 
             <footer class="event-card-footer">


### PR DESCRIPTION
## Summary

Implements Epic 10 Story 07: per-event statistics (invite count, RSVP count, accept count) on the event list page.

## Approach

Uses a single aggregated query with LEFT JOINs and GROUP BY, matching the existing `InviteRepository.GetStats` pattern. No N+1 queries — all stats computed in one SQL pass per page load.

```sql
SELECT e.*, 
    COUNT(DISTINCT i.id) AS invite_count,
    COUNT(DISTINCT r.id) AS rsvp_count,
    COUNT(DISTINCT CASE WHEN r.response = 'yes' THEN r.id END) AS accept_count
FROM events e
LEFT JOIN invites i ON e.id = i.event_id AND i.status != 'revoked'
LEFT JOIN rsvps r ON i.id = r.invite_id
WHERE ... GROUP BY e.id
```

## Changes

| Layer | Change |
|---|---|
| `models/event.go` | `EventWithStats` struct: embeds `Event` + `InviteCount`, `RSVPCount`, `AcceptCount` |
| `repositories/event_repository.go` | `ListWithStats` method: LEFT JOIN + GROUP BY + COUNT(DISTINCT) |
| `events/service.go` | `ListEventsWithStats`: same authz as `ListEvents` (managers see own, admins see all) |
| `handlers/events_web.go` | `ListEventsPage` calls `ListEventsWithStats`; `EventListPageData.Events` is now `[]*models.EventWithStats` |
| `event_list.html` | Stats row with icons and ARIA roles |
| Mocks | Regenerated `MockEventRepository` and `MockEventService` via mockgen |

## Design decisions

- **Non-revoked invites only**: `i.status != 'revoked'` in the JOIN condition, matching the story requirement
- **COUNT(DISTINCT)**: prevents Cartesian product inflation when an event has multiple invites AND each invite has multiple RSVPs
- **EventWithStats embeds Event (value, not pointer)**: avoids nil-dereference risk and keeps the struct self-contained
- **Placed in `models/` not `repositories/`**: follows the story spec and keeps the DTO accessible to all layers

## Tests
- `TestEventRepository_ListWithStats`: creates 2 events (one with invites/RSVPs, one empty), verifies counts (2 non-revoked invites, 2 RSVPs, 1 accept), verifies filter support, verifies empty event shows zero stats
- Updated `TestEventWebHandlers_ListEventsPage` to mock `ListEventsWithStats`

## Validation
- `go vet ./...` — clean
- `go build ./...` — clean
- Full suite (excluding UX) — all pass