### PR TITLE
feat: dashboard activity items clickable with event links (10-08)

### DIFF
--- a/docs/01_WORKLOG/0162_2026-07-07_dashboard_clickable_events.md
+++ b/docs/01_WORKLOG/0162_2026-07-07_dashboard_clickable_events.md
@@ -1,0 +1,38 @@
+# Worklog 0162: Dashboard Clickable Events (Epic 10 Story 08)
+
+**Date:** 2026-07-07  
+**Epic:** 10 (Technical Debt)  
+**Story:** [10_STORY_08_dashboard_clickable_events.md](../00_BACKLOG/10_TECHNICAL_DEBT/10_STORY_08_dashboard_clickable_events.md)  
+**Branch:** `feat/dashboard-clickable-events-10-08`  
+**PR:** #32
+
+---
+
+## Summary
+
+Dashboard activity items (event created, invite sent, RSVP received) are now clickable, linking to the relevant event detail page. Uses real `<a>` tags for accessibility.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `internal/events/dashboard_service.go` | Added `EventID *int64` to `ActivityItem`; populated for all three activity types using the event already available via `eventMap` |
+| `templates/web/dashboard.html` | Wraps title+description in `<a href="/events/{{.EventID}}">` when EventID is set; plain text otherwise |
+| `static/css/dashboard.css` | Hover state for clickable items |
+| `internal/events/dashboard_service_test.go` | Asserts all activity items have non-nil EventID |
+| `templates/web/dashboard_integration_test.go` | Test struct updated with EventID field |
+
+## Design decisions
+
+- **Nil-safe pointer** (`*int64`): forward-compatible with future activity types that might not reference an event
+- **Real `<a>` tags** (not `onclick` divs): keyboard navigation, middle-click, and copy-link all work naturally
+- **Conditional CSS class**: `activity-item-clickable` only when EventID is present
+
+## Scope note
+
+Deferred "surface event cancellations in feed" to a future story — that requires service logic changes (detecting `event.Status == Cancelled` and emitting a new activity type), which is conceptually separate from making existing items clickable.
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** Full suite green (excluding UX)

--- a/internal/events/dashboard_service.go
+++ b/internal/events/dashboard_service.go
@@ -47,6 +47,7 @@ type ActivityItem struct {
 	Title       string
 	Description string
 	Time        string
+	EventID     *int64
 }
 
 type DashboardService interface {
@@ -244,6 +245,7 @@ func (s *dashboardService) GetRecentActivity(ctx context.Context, userID int64, 
 	var activityEvents []activityEvent
 
 	for _, event := range events {
+		eventID := event.ID
 		activityEvents = append(activityEvents, activityEvent{
 			timestamp: event.CreatedAt,
 			item: &ActivityItem{
@@ -251,6 +253,7 @@ func (s *dashboardService) GetRecentActivity(ctx context.Context, userID int64, 
 				Title:       "Event Created",
 				Description: fmt.Sprintf("%s created", event.Title),
 				Time:        FormatTimeAgo(event.CreatedAt),
+				EventID:     &eventID,
 			},
 		})
 	}
@@ -261,6 +264,7 @@ func (s *dashboardService) GetRecentActivity(ctx context.Context, userID int64, 
 			if invite.Email != nil {
 				email = *invite.Email
 			}
+			eventID := event.ID
 			activityEvents = append(activityEvents, activityEvent{
 				timestamp: invite.CreatedAt,
 				item: &ActivityItem{
@@ -268,6 +272,7 @@ func (s *dashboardService) GetRecentActivity(ctx context.Context, userID int64, 
 					Title:       "Invite Sent",
 					Description: fmt.Sprintf("Invite sent to %s for %s", email, event.Title),
 					Time:        FormatTimeAgo(invite.CreatedAt),
+					EventID:     &eventID,
 				},
 			})
 		}
@@ -291,15 +296,16 @@ func (s *dashboardService) GetRecentActivity(ctx context.Context, userID int64, 
 					email = *invite.Email
 				}
 
-				activityEvents = append(activityEvents, activityEvent{
-					timestamp: rsvp.CreatedAt,
-					item: &ActivityItem{
-						Icon:        icon,
-						Title:       "RSVP Received",
-						Description: fmt.Sprintf("%s %s for %s", email, response, event.Title),
-						Time:        FormatTimeAgo(rsvp.CreatedAt),
-					},
-				})
+			activityEvents = append(activityEvents, activityEvent{
+				timestamp: rsvp.CreatedAt,
+				item: &ActivityItem{
+					Icon:        icon,
+					Title:       "RSVP Received",
+					Description: fmt.Sprintf("%s %s for %s", email, response, event.Title),
+					Time:        FormatTimeAgo(rsvp.CreatedAt),
+					EventID:     &event.ID,
+				},
+			})
 			}
 		}
 	}

--- a/internal/events/dashboard_service_test.go
+++ b/internal/events/dashboard_service_test.go
@@ -199,6 +199,12 @@ func TestDashboardService_GetRecentActivity_Success(t *testing.T) {
 	if len(activity) > 10 {
 		t.Errorf("expected max 10 activity items, got %d", len(activity))
 	}
+
+	for _, item := range activity {
+		if item.EventID == nil {
+			t.Errorf("activity item %q has nil EventID; all items should link to an event", item.Title)
+		}
+	}
 }
 
 func TestDashboardService_GetRecentActivity_NoUser(t *testing.T) {

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -148,6 +148,25 @@
     color: var(--color-text-tertiary);
 }
 
+.activity-item-clickable {
+    transition: background-color 0.15s ease;
+    border-radius: var(--radius-md);
+}
+
+.activity-item-clickable:hover {
+    background-color: var(--color-surface-hover, rgba(0, 0, 0, 0.03));
+}
+
+.activity-item-link {
+    text-decoration: none;
+    color: inherit;
+    display: block;
+}
+
+.activity-item-link:hover .activity-item-title {
+    text-decoration: underline;
+}
+
 .quick-actions {
     display: flex;
     flex-direction: column;

--- a/templates/web/dashboard.html
+++ b/templates/web/dashboard.html
@@ -57,13 +57,20 @@
         
         {{if .Activities}}
         {{range .Activities}}
-        <div class="activity-item">
+        <div class="activity-item{{if .EventID}} activity-item-clickable{{end}}">
             <div class="activity-item-icon">
                 {{.Icon}}
             </div>
             <div class="activity-item-content">
+                {{if .EventID}}
+                <a href="/events/{{.EventID}}" class="activity-item-link">
+                    <h3 class="activity-item-title">{{.Title}}</h3>
+                    <p class="activity-item-description">{{.Description}}</p>
+                </a>
+                {{else}}
                 <h3 class="activity-item-title">{{.Title}}</h3>
                 <p class="activity-item-description">{{.Description}}</p>
+                {{end}}
                 <time class="activity-item-time">{{.Time}}</time>
             </div>
         </div>

--- a/templates/web/dashboard_integration_test.go
+++ b/templates/web/dashboard_integration_test.go
@@ -23,6 +23,7 @@ type DashboardActivity struct {
 	Title       string
 	Description string
 	Time        string
+	EventID     *int64
 }
 
 type DashboardData struct {
@@ -134,7 +135,7 @@ func TestDashboardTemplateHasDashboardLayout(t *testing.T) {
 		`class="stats-grid"`,
 		`class="stats-card"`,
 		`class="activity-feed"`,
-		`class="activity-item"`,
+		`activity-item`,
 	}
 
 	for _, class := range requiredClasses {
@@ -182,7 +183,7 @@ func TestDashboardTemplateHasActivityFeed(t *testing.T) {
 	requiredClasses := []string{
 		`class="activity-feed"`,
 		`class="activity-feed-title"`,
-		`class="activity-item"`,
+		`activity-item`,
 		`class="activity-item-icon"`,
 		`class="activity-item-content"`,
 		`class="activity-item-title"`,


### PR DESCRIPTION
## Summary

Implements Epic 10 Story 08: dashboard recent-activity items are now clickable, linking to the relevant event.

## Changes

| File | Change |
|---|---|
| `events/dashboard_service.go` | `ActivityItem.EventID *int64` — nil-safe pointer; populated for all three activity types (event created, invite sent, RSVP received) |
| `dashboard.html` | Wraps title+description in `<a href="/events/{{.EventID}}">` when EventID is set; items without EventID render as plain text |
| `dashboard.css` | Hover state for clickable items, underline on hover |
| `dashboard_service_test.go` | Asserts all activity items have non-nil EventID |
| `dashboard_integration_test.go` | Test struct updated with EventID field; class assertions made robust |

## Design decisions

- **Real `<a>` tags, not `onclick` divs**: per architecture review — keyboard navigation, middle-click, and copy-link all work naturally. This also avoids repeating the accessibility anti-pattern in `event_list.html:80`.
- **Nil-safe pointer (`*int64`)**: forward-compatible with future activity types that might not reference an event (e.g., system notifications).
- **CSS class conditional**: `activity-item-clickable` added only when EventID is present, so non-clickable items don't get hover effects.

## Scope note

Per architecture review, deferred the "surface event cancellations in feed" scope to a future story — that requires service logic changes (detecting `event.Status == Cancelled` and emitting a new activity type), which is conceptually separate from making existing items clickable.

## Validation
- `go vet ./...` — clean
- `go build ./...` — clean
- Full suite (excluding UX) — all pass