### PR TITLE
feat: admin metrics dashboard with direct data sources (10-11)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -644,6 +644,21 @@ func main() {
 		json.NewEncoder(w).Encode(status)
 	})
 
+	metricsTemplates, err := template.New("admin_metrics.html").Funcs(funcMap).ParseFiles(
+		"templates/web/partials/base.html",
+		"templates/web/partials/navigation.html",
+		"templates/web/partials/page_header.html",
+		"templates/web/admin_metrics.html",
+	)
+	if err != nil {
+		logger.Error("Failed to load admin metrics templates", "error", err)
+		os.Exit(1)
+	}
+	metricsDataSource := handlers.NewMetricsDataSource(adminService, emailHealthChecker, database)
+	adminMetricsHandler := handlers.NewMetricsHandler(metricsDataSource)
+	adminMetricsHandler.SetTemplates(metricsTemplates)
+	logger.Info("Admin metrics templates loaded successfully")
+
 	router := handlers.NewRouter(&handlers.RouterHandlers{
 		LoginHandler:             loginHandler,
 		CallbackHandler:          callbackHandler,
@@ -673,6 +688,7 @@ func main() {
 		AdminDashboardHandler:    adminDashboardHandler,
 		UserManagementHandler:    userManagementHandler,
 		SettingsHandler:          settingsHandler,
+		AdminMetricsHandler:      adminMetricsHandler,
 		TemplateHandlers:         templateHandlers,
 		TemplateEditorHandlers:   templateEditorHandlers,
 		CustomizationHandlers:    customizationHandlers,

--- a/docs/01_WORKLOG/0163_2026-07-07_admin_metrics_dashboard.md
+++ b/docs/01_WORKLOG/0163_2026-07-07_admin_metrics_dashboard.md
@@ -1,0 +1,49 @@
+# Worklog 0163: Admin Metrics Dashboard (Epic 10 Story 11)
+
+**Date:** 2026-07-07  
+**Epic:** 10 (Technical Debt)  
+**Story:** [10_STORY_11_admin_metrics_dashboard.md](../00_BACKLOG/10_TECHNICAL_DEBT/10_STORY_11_admin_metrics_dashboard.md)  
+**Branch:** `feat/admin-metrics-dashboard-10-11`
+
+---
+
+## Summary
+
+Admin metrics page at `/admin/metrics` that displays business counts, database connection pool stats, and email queue status. Reads data sources directly rather than scraping/parseing Prometheus text format.
+
+## Approach
+
+Per architecture review, did NOT scrape `/metrics` and parse the text exposition format. Instead, created a `MetricsDataSource` interface with three methods that read underlying systems directly:
+
+1. `GetAdminStats` → reuses `admin.AdminService.GetAdminStats` (user/event/invite totals)
+2. `GetEmailQueueStatus` → reuses `email.HealthChecker.GetStatus` (queue size, sending, failed, healthy)
+3. `GetDBStats` → reads `database.DB().Stats()` (open/in-use/idle connections, wait count/duration)
+
+This avoids the circular dependency of scraping `/metrics` to display metrics.
+
+**Prerequisite:** The metrics middleware wiring bug (PR #30) is already merged, so `/metrics` now has real Prometheus data for scraping. This page is for human-friendly HTML display.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `internal/handlers/metrics.go` | `MetricsHandler`, `MetricsDataSource` interface, data structs (`AdminMetricsStats`, `EmailQueueMetrics`, `DBPoolMetrics`) |
+| `internal/handlers/metrics_adapter.go` | `metricsDataSource` implementation wiring admin service + email checker + database |
+| `templates/web/admin_metrics.html` | Human-friendly metrics display |
+| `static/css/admin_metrics.css` | Responsive layout |
+| `templates/web/admin_dashboard.html` | Added "System Metrics" quick action card |
+| `internal/handlers/router.go` | `AdminMetricsHandlerInterface`, route `/admin/metrics` with RequireAuth+RequireAdmin |
+| `cmd/server/main.go` | Template parsing, data source + handler construction, RouterHandlers wiring |
+
+## Design decisions
+
+- **Direct data sources, not Prometheus parsing**: avoids brittle text format parsing and circular dependency
+- **Named `AdminMetricsHandler`** (not `MetricsHandler`) to avoid conflict with the existing `MetricsHandler` field for the `/metrics` Prometheus endpoint
+- **Graceful degradation**: if email queue or DB stats fail to load, the page still renders with whatever data is available
+- **Prometheus link**: the page links to `/metrics` for machine scraping, keeping this page for human consumption
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** Full suite green (excluding UX)  
+**Confidence:** HIGH

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"html/template"
+	"log"
 	"net/http"
 	"time"
 
@@ -88,12 +89,16 @@ func (h *MetricsHandler) MetricsPage(w http.ResponseWriter, r *http.Request) {
 	data.Stats = stats
 
 	emailQueue, err := h.source.GetEmailQueueStatus(r.Context())
-	if err == nil {
+	if err != nil {
+		log.Printf("Metrics: failed to load email queue status: %v", err)
+	} else {
 		data.EmailQueue = emailQueue
 	}
 
 	dbPool, err := h.source.GetDBStats()
-	if err == nil {
+	if err != nil {
+		log.Printf("Metrics: failed to load DB pool stats: %v", err)
+	} else {
 		data.DBPool = dbPool
 	}
 

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"html/template"
+	"net/http"
+	"time"
+
+	"github.com/lenaxia/tinyrsvp/internal/auth"
+	"github.com/lenaxia/tinyrsvp/internal/models"
+)
+
+type MetricsDataSource interface {
+	GetAdminStats(ctx context.Context) (*AdminMetricsStats, error)
+	GetEmailQueueStatus(ctx context.Context) (*EmailQueueMetrics, error)
+	GetDBStats() (*DBPoolMetrics, error)
+}
+
+type AdminMetricsStats struct {
+	TotalUsers   int
+	TotalEvents  int
+	TotalInvites int
+}
+
+type EmailQueueMetrics struct {
+	QueueSize    int
+	SendingCount int
+	FailedCount  int
+	Healthy      bool
+}
+
+type DBPoolMetrics struct {
+	OpenConnections int
+	InUse           int
+	Idle            int
+	WaitCount       int64
+	WaitDuration    time.Duration
+	MaxOpenConnections int
+}
+
+type MetricsHandler struct {
+	source    MetricsDataSource
+	templates *template.Template
+}
+
+type MetricsPageData struct {
+	ActivePage string
+	User       *models.User
+	Stats      *AdminMetricsStats
+	EmailQueue *EmailQueueMetrics
+	DBPool     *DBPoolMetrics
+	Error      string
+	GeneratedAt time.Time
+}
+
+func NewMetricsHandler(source MetricsDataSource) *MetricsHandler {
+	return &MetricsHandler{source: source}
+}
+
+func (h *MetricsHandler) SetTemplates(tmpl *template.Template) {
+	h.templates = tmpl
+}
+
+func (h *MetricsHandler) MetricsPage(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		HandleError(w, r, &models.PermissionDeniedError{
+			Action:   "view admin metrics",
+			Resource: "Admin Metrics",
+		})
+		return
+	}
+
+	data := &MetricsPageData{
+		ActivePage:  "admin",
+		User:        user,
+		GeneratedAt: time.Now(),
+	}
+
+	stats, err := h.source.GetAdminStats(r.Context())
+	if err != nil {
+		data.Error = fmt.Sprintf("Failed to load stats: %v", err)
+		h.renderPage(w, http.StatusOK, data)
+		return
+	}
+	data.Stats = stats
+
+	emailQueue, err := h.source.GetEmailQueueStatus(r.Context())
+	if err == nil {
+		data.EmailQueue = emailQueue
+	}
+
+	dbPool, err := h.source.GetDBStats()
+	if err == nil {
+		data.DBPool = dbPool
+	}
+
+	h.renderPage(w, http.StatusOK, data)
+}
+
+func (h *MetricsHandler) renderPage(w http.ResponseWriter, status int, data *MetricsPageData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+
+	if h.templates != nil {
+		if err := h.templates.ExecuteTemplate(w, "admin_metrics.html", data); err != nil {
+			http.Error(w, "Failed to render page", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	fmt.Fprintf(w, `<!DOCTYPE html><html><head><title>Admin Metrics</title></head><body><h1>Metrics</h1></body></html>`)
+}
+
+func NewDBPoolMetricsFromSQLDB(db *sql.DB) *DBPoolMetrics {
+	stats := db.Stats()
+	return &DBPoolMetrics{
+		OpenConnections:    stats.OpenConnections,
+		InUse:              stats.InUse,
+		Idle:               stats.Idle,
+		WaitCount:          stats.WaitCount,
+		WaitDuration:       stats.WaitDuration,
+		MaxOpenConnections: stats.MaxOpenConnections,
+	}
+}

--- a/internal/handlers/metrics_adapter.go
+++ b/internal/handlers/metrics_adapter.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/lenaxia/tinyrsvp/internal/db"
+	"github.com/lenaxia/tinyrsvp/internal/email"
+)
+
+type EmailHealthChecker interface {
+	GetStatus(ctx context.Context) (*email.HealthStatus, error)
+}
+
+type metricsDataSource struct {
+	adminService AdminDashboardService
+	emailChecker EmailHealthChecker
+	database     db.Database
+}
+
+func NewMetricsDataSource(adminSvc AdminDashboardService, emailChk EmailHealthChecker, database db.Database) MetricsDataSource {
+	return &metricsDataSource{
+		adminService: adminSvc,
+		emailChecker: emailChk,
+		database:     database,
+	}
+}
+
+func (s *metricsDataSource) GetAdminStats(ctx context.Context) (*AdminMetricsStats, error) {
+	stats, err := s.adminService.GetAdminStats(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &AdminMetricsStats{
+		TotalUsers:   stats.TotalUsers,
+		TotalEvents:  stats.TotalEvents,
+		TotalInvites: stats.TotalInvites,
+	}, nil
+}
+
+func (s *metricsDataSource) GetEmailQueueStatus(ctx context.Context) (*EmailQueueMetrics, error) {
+	status, err := s.emailChecker.GetStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &EmailQueueMetrics{
+		QueueSize:    status.QueueSize,
+		SendingCount: status.SendingCount,
+		FailedCount:  status.FailedCount,
+		Healthy:      status.Healthy,
+	}, nil
+}
+
+func (s *metricsDataSource) GetDBStats() (*DBPoolMetrics, error) {
+	return NewDBPoolMetricsFromSQLDB(s.database.DB()), nil
+}
+
+var _ MetricsDataSource = (*metricsDataSource)(nil)

--- a/internal/handlers/metrics_test.go
+++ b/internal/handlers/metrics_test.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lenaxia/tinyrsvp/internal/testutil"
+)
+
+type mockMetricsDataSource struct {
+	statsFunc    func(ctx context.Context) (*AdminMetricsStats, error)
+	emailFunc    func(ctx context.Context) (*EmailQueueMetrics, error)
+	dbFunc       func() (*DBPoolMetrics, error)
+}
+
+func (m *mockMetricsDataSource) GetAdminStats(ctx context.Context) (*AdminMetricsStats, error) {
+	if m.statsFunc != nil {
+		return m.statsFunc(ctx)
+	}
+	return &AdminMetricsStats{TotalUsers: 10, TotalEvents: 5, TotalInvites: 20}, nil
+}
+
+func (m *mockMetricsDataSource) GetEmailQueueStatus(ctx context.Context) (*EmailQueueMetrics, error) {
+	if m.emailFunc != nil {
+		return m.emailFunc(ctx)
+	}
+	return &EmailQueueMetrics{QueueSize: 3, SendingCount: 1, FailedCount: 0, Healthy: true}, nil
+}
+
+func (m *mockMetricsDataSource) GetDBStats() (*DBPoolMetrics, error) {
+	if m.dbFunc != nil {
+		return m.dbFunc()
+	}
+	return &DBPoolMetrics{OpenConnections: 5, InUse: 2, Idle: 3, MaxOpenConnections: 10}, nil
+}
+
+func TestMetricsPage_Success(t *testing.T) {
+	handler := NewMetricsHandler(&mockMetricsDataSource{})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/admin/metrics", nil)
+	ctx := testutil.CreateAdminContext()
+	r = r.WithContext(ctx)
+
+	handler.MetricsPage(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestMetricsPage_Unauthorized(t *testing.T) {
+	handler := NewMetricsHandler(&mockMetricsDataSource{})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/admin/metrics", nil)
+	r.Header.Set("Accept", "application/json")
+
+	handler.MetricsPage(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Expected status %d for missing user, got %d", http.StatusForbidden, w.Code)
+	}
+}
+
+func TestMetricsPage_ServiceError(t *testing.T) {
+	handler := NewMetricsHandler(&mockMetricsDataSource{
+		statsFunc: func(ctx context.Context) (*AdminMetricsStats, error) {
+			return nil, fmt.Errorf("database unavailable")
+		},
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/admin/metrics", nil)
+	r = r.WithContext(testutil.CreateAdminContext())
+
+	handler.MetricsPage(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d (page renders with error), got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestMetricsPage_PartialFailure(t *testing.T) {
+	handler := NewMetricsHandler(&mockMetricsDataSource{
+		emailFunc: func(ctx context.Context) (*EmailQueueMetrics, error) {
+			return nil, fmt.Errorf("email checker unavailable")
+		},
+		dbFunc: func() (*DBPoolMetrics, error) {
+			return nil, fmt.Errorf("db stats unavailable")
+		},
+	})
+
+	data := &MetricsPageData{}
+	_ = data
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/admin/metrics", nil)
+	r = r.WithContext(testutil.CreateAdminContext())
+
+	handler.MetricsPage(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d with graceful degradation, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestNewDBPoolMetricsFromSQLDB(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Skipf("sqlite3 not available: %v", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(5)
+	metrics := NewDBPoolMetricsFromSQLDB(db)
+
+	if metrics.MaxOpenConnections != 5 {
+		t.Errorf("MaxOpenConnections = %d, want 5", metrics.MaxOpenConnections)
+	}
+	if metrics.OpenConnections < 0 {
+		t.Errorf("OpenConnections should be >= 0, got %d", metrics.OpenConnections)
+	}
+}

--- a/internal/handlers/router.go
+++ b/internal/handlers/router.go
@@ -65,6 +65,7 @@ type RouterHandlers struct {
 	AdminDashboardHandler AdminDashboardHandlerInterface
 	UserManagementHandler UserManagementHandlerInterface
 	SettingsHandler       SettingsHandlerInterface
+	AdminMetricsHandler   AdminMetricsHandlerInterface
 
 	CleanupHandler     http.Handler
 	EmailHealthHandler http.Handler
@@ -198,6 +199,10 @@ type UserManagementHandlerInterface interface {
 
 type SettingsHandlerInterface interface {
 	SettingsPage(w http.ResponseWriter, r *http.Request)
+}
+
+type AdminMetricsHandlerInterface interface {
+	MetricsPage(w http.ResponseWriter, r *http.Request)
 }
 
 type AuthMiddlewareInterface interface {
@@ -365,6 +370,14 @@ func NewRouter(handlers *RouterHandlers) *Router {
 		r.Handle("/admin/settings", handlers.AuthMiddleware.RequireAuth(
 			handlers.AuthMiddleware.RequireAdmin(
 				http.HandlerFunc(handlers.SettingsHandler.SettingsPage),
+			),
+		))
+	}
+
+	if handlers.AdminMetricsHandler != nil && handlers.AuthMiddleware != nil {
+		r.Handle("/admin/metrics", handlers.AuthMiddleware.RequireAuth(
+			handlers.AuthMiddleware.RequireAdmin(
+				http.HandlerFunc(handlers.AdminMetricsHandler.MetricsPage),
 			),
 		))
 	}

--- a/static/css/admin_metrics.css
+++ b/static/css/admin_metrics.css
@@ -1,0 +1,111 @@
+.metrics-container {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.metrics-section {
+    margin-bottom: var(--spacing-8);
+}
+
+.metrics-section-title {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+    margin-bottom: var(--spacing-4);
+    padding-bottom: var(--spacing-2);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--spacing-4);
+}
+
+.metric-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: var(--spacing-6) var(--spacing-4);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+}
+
+.metric-value {
+    font-size: var(--font-size-3xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-primary);
+    line-height: 1;
+}
+
+.metric-label {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    margin-top: var(--spacing-2);
+}
+
+.metrics-detail-grid {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: var(--spacing-2) var(--spacing-4);
+}
+
+.metrics-detail-grid dt {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    font-weight: var(--font-weight-medium);
+}
+
+.metrics-detail-grid dd {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-primary);
+}
+
+.metrics-note {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    padding: var(--spacing-3);
+    background-color: var(--color-surface-secondary, #f5f5f5);
+    border-radius: var(--radius-md);
+}
+
+.metrics-note a {
+    color: var(--color-primary);
+}
+
+.status-badge {
+    display: inline-block;
+    padding: var(--spacing-1) var(--spacing-3);
+    border-radius: var(--radius-full);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    text-transform: uppercase;
+}
+
+.status-healthy {
+    background-color: var(--color-success-bg, #d4edda);
+    color: var(--color-success-text, #155724);
+}
+
+.status-unhealthy {
+    background-color: var(--color-danger-bg, #f8d7da);
+    color: var(--color-danger-text, #721c24);
+}
+
+.metrics-generated-at {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-tertiary);
+    text-align: right;
+    margin-top: var(--spacing-6);
+}
+
+@media (max-width: 640px) {
+    .metrics-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .metrics-detail-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/templates/web/admin_dashboard.html
+++ b/templates/web/admin_dashboard.html
@@ -55,6 +55,10 @@
                 <h3>System Settings</h3>
                 <p>View server configuration</p>
             </a>
+            <a href="/admin/metrics" class="action-card">
+                <h3>System Metrics</h3>
+                <p>View system health and performance</p>
+            </a>
         </div>
     </section>
 

--- a/templates/web/admin_metrics.html
+++ b/templates/web/admin_metrics.html
@@ -1,0 +1,82 @@
+{{template "base" .}}
+
+{{define "title"}}Admin Metrics - TinyRSVP{{end}}
+
+{{define "main-class"}}admin-metrics{{end}}
+
+{{define "content"}}
+{{template "page-header" dict "Title" "System Metrics" "Actions" (printf "<span>%s (%s)</span>" .User.Name .User.Role)}}
+
+<div class="metrics-container">
+    {{if .Error}}
+    <div class="error-state" role="alert">
+        <p>{{.Error}}</p>
+    </div>
+    {{end}}
+
+    {{if .Stats}}
+    <section class="metrics-section">
+        <h2 class="metrics-section-title">Business Metrics</h2>
+        <div class="metrics-grid">
+            <div class="metric-card">
+                <span class="metric-value">{{.Stats.TotalUsers}}</span>
+                <span class="metric-label">Total Users</span>
+            </div>
+            <div class="metric-card">
+                <span class="metric-value">{{.Stats.TotalEvents}}</span>
+                <span class="metric-label">Total Events</span>
+            </div>
+            <div class="metric-card">
+                <span class="metric-value">{{.Stats.TotalInvites}}</span>
+                <span class="metric-label">Total Invites</span>
+            </div>
+        </div>
+    </section>
+    {{end}}
+
+    {{if .DBPool}}
+    <section class="metrics-section">
+        <h2 class="metrics-section-title">Database Connection Pool</h2>
+        <dl class="metrics-detail-grid">
+            <dt>Open Connections</dt><dd>{{.DBPool.OpenConnections}} / {{.DBPool.MaxOpenConnections}}</dd>
+            <dt>In Use</dt><dd>{{.DBPool.InUse}}</dd>
+            <dt>Idle</dt><dd>{{.DBPool.Idle}}</dd>
+            <dt>Wait Count</dt><dd>{{.DBPool.WaitCount}}</dd>
+            <dt>Wait Duration</dt><dd>{{.DBPool.WaitDuration}}</dd>
+        </dl>
+    </section>
+    {{end}}
+
+    {{if .EmailQueue}}
+    <section class="metrics-section">
+        <h2 class="metrics-section-title">Email Queue</h2>
+        <dl class="metrics-detail-grid">
+            <dt>Status</dt>
+            <dd>
+                {{if .EmailQueue.Healthy}}
+                <span class="status-badge status-healthy">Healthy</span>
+                {{else}}
+                <span class="status-badge status-unhealthy">Unhealthy</span>
+                {{end}}
+            </dd>
+            <dt>Queue Size (pending)</dt><dd>{{.EmailQueue.QueueSize}}</dd>
+            <dt>Sending</dt><dd>{{.EmailQueue.SendingCount}}</dd>
+            <dt>Failed</dt><dd>{{.EmailQueue.FailedCount}}</dd>
+        </dl>
+    </section>
+    {{end}}
+
+    <section class="metrics-section">
+        <h2 class="metrics-section-title">Prometheus</h2>
+        <p class="metrics-note">
+            Raw Prometheus metrics are available at
+            <a href="/metrics">/metrics</a> for scraping by monitoring systems
+            (Prometheus, Grafana, Datadog).
+        </p>
+    </section>
+
+    <p class="metrics-generated-at">
+        Generated at {{.GeneratedAt.Format "Jan 2, 2006 at 3:04:05 PM"}}
+    </p>
+</div>
+{{end}}

--- a/templates/web/partials/base.html
+++ b/templates/web/partials/base.html
@@ -35,6 +35,7 @@
     <link rel="stylesheet" href="/static/css/app_navigation.css">
     <link rel="stylesheet" href="/static/css/dashboard.css">
     <link rel="stylesheet" href="/static/css/admin_settings.css">
+    <link rel="stylesheet" href="/static/css/admin_metrics.css">
     <link rel="stylesheet" href="/static/css/mobile_optimization.css">
     <link rel="stylesheet" href="/static/css/loading_states.css">
     <link rel="stylesheet" href="/static/css/error_display.css">


### PR DESCRIPTION
## Summary

Implements Epic 10 Story 11: admin metrics page at `/admin/metrics` displaying business counts, database connection pool stats, and email queue status.

## Design (per architecture review)

**Does NOT scrape/parse Prometheus text format.** Instead, reads data sources directly via a `MetricsDataSource` interface:

| Source | Method | Data |
|---|---|---|
| `admin.AdminService` | `GetAdminStats` | User/event/invite totals |
| `email.HealthChecker` | `GetStatus` | Queue size, sending count, failed count, healthy flag |
| `database.DB()` | `.Stats()` | Open/in-use/idle connections, wait count/duration |

This avoids the circular dependency and brittleness of scraping `/metrics` to display metrics.

**Prerequisite met:** The metrics middleware wiring bug (PR #30) is already merged, so `/metrics` now returns real Prometheus data for scraping. This page is for human-friendly HTML display.

## Files

| File | Change |
|---|---|
| `handlers/metrics.go` | `AdminMetricsHandler`, `MetricsDataSource` interface, data structs |
| `handlers/metrics_adapter.go` | Wires admin service + email checker + database |
| `admin_metrics.html` | Human-friendly display with cards and detail grids |
| `admin_metrics.css` | Responsive layout |
| `admin_dashboard.html` | Added "System Metrics" quick action card |
| `router.go` + `main.go` | Route + handler wiring |

## Naming

Named `AdminMetricsHandler` (not `MetricsHandler`) to avoid conflict with the existing `MetricsHandler` field (type `http.Handler`) used for the `/metrics` Prometheus endpoint.

## Validation
- `go vet ./...` — clean
- `go build ./...` — clean
- Full suite (excluding UX) — all pass