### PR TITLE
refactor: replace hand-rolled /api/users routing with chi routes (G7)

### DIFF
--- a/docs/01_WORKLOG/0169_2026-07-08_g7_api_users_routing.md
+++ b/docs/01_WORKLOG/0169_2026-07-08_g7_api_users_routing.md
@@ -1,0 +1,46 @@
+# Worklog 0169: Replace Hand-Rolled /api/users Routing with Chi Routes (G7)
+
+**Date:** 2026-07-08  
+**Epic:** 10 (Technical Debt)  
+**Branch:** `cleanup/G7-api-users-routing`  
+**PR:** #42
+
+---
+
+## Summary
+
+Replaced the hand-rolled path-parsing routing for `/api/users/{id}` with proper chi routes. Eliminated ~60 lines of manual path splitting, `_method` override handling, and per-method auth middleware wrapping.
+
+## Changes
+
+### Router (`internal/handlers/router.go`)
+
+**Before** (60 lines): manual `strings.TrimPrefix`, `strings.Split`, switch on method, `RequireAuth(RequireAdmin(http.HandlerFunc(...)))` repeated 3 times.
+
+**After** (20 lines):
+```go
+r.Route("/api/users", func(r chi.Router) {
+    r.Use(AuthMiddleware.RequireAuth)
+    r.Use(AuthMiddleware.RequireAdmin)
+    r.Use(methodOverrideMiddleware)
+    r.Get("/", ListUsers)
+    r.Get("/{id}", GetUser)
+    r.Patch("/{id}", UpdateUserRole)
+    r.Delete("/{id}", DeleteUser)
+})
+```
+
+### Handler signatures (`internal/handlers/users.go`)
+
+Changed `GetUser`, `UpdateUserRole`, `DeleteUser` from taking `(w, r, userID string)` to `(w, r)` only, reading `userID` from `chi.URLParam(r, "id")` — matching the pattern used by all other handlers.
+
+### Tests
+
+- `internal/handlers/users_test.go` and `users_integration_test.go`: added `reqWithUserIDParam` helper to set chi URL params on test requests
+- `tests/e2e/auth_flow_test.go`: updated to use `chi.NewRouteContext` for URL param injection
+- `internal/handlers/router_real_handlers_test.go`: updated mock signatures
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** Full suite green

--- a/internal/handlers/router.go
+++ b/internal/handlers/router.go
@@ -171,9 +171,9 @@ type RSVPSummaryHandlerInterface interface {
 
 type UserHandlerInterface interface {
 	ListUsers(w http.ResponseWriter, r *http.Request)
-	GetUser(w http.ResponseWriter, r *http.Request, userID string)
-	UpdateUserRole(w http.ResponseWriter, r *http.Request, userID string)
-	DeleteUser(w http.ResponseWriter, r *http.Request, userID string)
+	GetUser(w http.ResponseWriter, r *http.Request)
+	UpdateUserRole(w http.ResponseWriter, r *http.Request)
+	DeleteUser(w http.ResponseWriter, r *http.Request)
 }
 
 type TemplateHandlerInterface interface {
@@ -509,61 +509,31 @@ func NewRouter(handlers *RouterHandlers) *Router {
 
 	if handlers.UserHandler != nil {
 		if handlers.AuthMiddleware != nil {
-			r.Handle("/api/users", handlers.AuthMiddleware.RequireAuth(
-				handlers.AuthMiddleware.RequireAdmin(
-					http.HandlerFunc(handlers.UserHandler.ListUsers),
-				),
-			))
+			r.Route("/api/users", func(r chi.Router) {
+				r.Use(handlers.AuthMiddleware.RequireAuth)
+				r.Use(handlers.AuthMiddleware.RequireAdmin)
 
-			r.HandleFunc("/api/users/", func(w http.ResponseWriter, req *http.Request) {
-				path := strings.TrimPrefix(req.URL.Path, "/api/users/")
-				if path == "" {
-					http.NotFound(w, req)
-					return
-				}
-
-				parts := strings.Split(path, "/")
-				userID := parts[0]
-
-				// Support _method override for HTML form submissions
-				// (browsers can only submit GET/POST; forms use hidden _method field)
-				method := req.Method
-				if method == http.MethodPost {
-					if err := req.ParseForm(); err == nil {
-						if override := req.FormValue("_method"); override != "" {
-							method = strings.ToUpper(override)
+				// Method override middleware: HTML forms can only submit
+				// GET/POST, so forms use a hidden _method field to signal
+				// PATCH/DELETE. This middleware translates POST + _method
+				// to the intended HTTP method before chi routes it.
+				r.Use(func(next http.Handler) http.Handler {
+					return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if r.Method == http.MethodPost {
+							if err := r.ParseForm(); err == nil {
+								if override := r.FormValue("_method"); override != "" {
+									r.Method = strings.ToUpper(override)
+								}
+							}
 						}
-					}
-				}
+						next.ServeHTTP(w, r)
+					})
+				})
 
-				switch method {
-				case http.MethodGet:
-					handlers.AuthMiddleware.RequireAuth(
-						handlers.AuthMiddleware.RequireAdmin(
-							http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-								handlers.UserHandler.GetUser(w, r, userID)
-							}),
-						),
-					).ServeHTTP(w, req)
-				case http.MethodPatch:
-					handlers.AuthMiddleware.RequireAuth(
-						handlers.AuthMiddleware.RequireAdmin(
-							http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-								handlers.UserHandler.UpdateUserRole(w, r, userID)
-							}),
-						),
-					).ServeHTTP(w, req)
-				case http.MethodDelete:
-					handlers.AuthMiddleware.RequireAuth(
-						handlers.AuthMiddleware.RequireAdmin(
-							http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-								handlers.UserHandler.DeleteUser(w, r, userID)
-							}),
-						),
-					).ServeHTTP(w, req)
-				default:
-					http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-				}
+				r.Get("/", handlers.UserHandler.ListUsers)
+				r.Get("/{id}", handlers.UserHandler.GetUser)
+				r.Patch("/{id}", handlers.UserHandler.UpdateUserRole)
+				r.Delete("/{id}", handlers.UserHandler.DeleteUser)
 			})
 		}
 	}

--- a/internal/handlers/router_real_handlers_test.go
+++ b/internal/handlers/router_real_handlers_test.go
@@ -126,17 +126,17 @@ func (m *mockUserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode([]interface{}{})
 }
 
-func (m *mockUserHandler) GetUser(w http.ResponseWriter, r *http.Request, userID string) {
+func (m *mockUserHandler) GetUser(w http.ResponseWriter, r *http.Request) {
 	m.getCalled = true
 	w.WriteHeader(http.StatusOK)
 }
 
-func (m *mockUserHandler) UpdateUserRole(w http.ResponseWriter, r *http.Request, userID string) {
+func (m *mockUserHandler) UpdateUserRole(w http.ResponseWriter, r *http.Request) {
 	m.updateCalled = true
 	w.WriteHeader(http.StatusOK)
 }
 
-func (m *mockUserHandler) DeleteUser(w http.ResponseWriter, r *http.Request, userID string) {
+func (m *mockUserHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	m.deleteCalled = true
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/lenaxia/tinyrsvp/internal/auth"
 	"github.com/lenaxia/tinyrsvp/internal/models"
 )
@@ -108,14 +109,14 @@ func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusOK, response)
 }
 
-func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request, userIDStr string) {
+func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request) {
 	currentUser, _ := auth.UserFromContext(r.Context())
 	if !h.authChecker.CanManageUsers(r.Context(), currentUser) {
 		HandleError(w, r, NewPermissionDeniedError("insufficient permissions"))
 		return
 	}
 
-	userID, err := parseUserID(userIDStr)
+	userID, err := parseUserID(chi.URLParam(r, "id"))
 	if err != nil {
 		HandleError(w, r, NewBadRequestError("invalid user ID"))
 		return
@@ -130,14 +131,14 @@ func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request, userIDStr 
 	respondJSON(w, http.StatusOK, toUserDTO(user))
 }
 
-func (h *UserHandler) UpdateUserRole(w http.ResponseWriter, r *http.Request, userIDStr string) {
+func (h *UserHandler) UpdateUserRole(w http.ResponseWriter, r *http.Request) {
 	currentUser, _ := auth.UserFromContext(r.Context())
 	if !h.authChecker.CanManageUsers(r.Context(), currentUser) {
 		HandleError(w, r, NewPermissionDeniedError("insufficient permissions"))
 		return
 	}
 
-	userID, err := parseUserID(userIDStr)
+	userID, err := parseUserID(chi.URLParam(r, "id"))
 	if err != nil {
 		HandleError(w, r, NewBadRequestError("invalid user ID"))
 		return
@@ -183,14 +184,14 @@ func (h *UserHandler) UpdateUserRole(w http.ResponseWriter, r *http.Request, use
 	respondJSON(w, http.StatusOK, toUserDTO(user))
 }
 
-func (h *UserHandler) DeleteUser(w http.ResponseWriter, r *http.Request, userIDStr string) {
+func (h *UserHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	currentUser, _ := auth.UserFromContext(r.Context())
 	if !h.authChecker.CanManageUsers(r.Context(), currentUser) {
 		HandleError(w, r, NewPermissionDeniedError("insufficient permissions"))
 		return
 	}
 
-	userID, err := parseUserID(userIDStr)
+	userID, err := parseUserID(chi.URLParam(r, "id"))
 	if err != nil {
 		HandleError(w, r, NewBadRequestError("invalid user ID"))
 		return

--- a/internal/handlers/users_integration_test.go
+++ b/internal/handlers/users_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/lenaxia/tinyrsvp/internal/auth"
 	"github.com/lenaxia/tinyrsvp/internal/db"
 	"github.com/lenaxia/tinyrsvp/internal/db/repositories"
@@ -102,7 +103,7 @@ func TestDeleteUser_CascadesSessions(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	handler.DeleteUser(w, req, "2")
+	handler.DeleteUser(w, reqWithUserIDParam(req, "2"))
 
 	if w.Code != http.StatusNoContent {
 		t.Errorf("Expected status 204, got %d", w.Code)
@@ -148,7 +149,7 @@ func TestDeleteUser_LastAdminProtection(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	handler.DeleteUser(w, req, "1")
+	handler.DeleteUser(w, reqWithUserIDParam(req, "1"))
 
 	if w.Code != http.StatusConflict {
 		t.Errorf("Expected status 409 (Conflict), got %d", w.Code)
@@ -187,7 +188,7 @@ func TestUpdateUserRole_LastAdminProtection(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	handler.UpdateUserRole(w, req, "1")
+	handler.UpdateUserRole(w, reqWithUserIDParam(req, "1"))
 
 	if w.Code != http.StatusConflict {
 		t.Errorf("Expected status 409 (Conflict), got %d", w.Code)
@@ -302,7 +303,7 @@ func TestGetUser_PermissionCheck_AdminAllowed(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	handler.GetUser(w, req, "2")
+	handler.GetUser(w, reqWithUserIDParam(req, "2"))
 
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status 200 for admin, got %d", w.Code)
@@ -343,7 +344,7 @@ func TestGetUser_PermissionCheck_NonAdminDenied(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	handler.GetUser(w, req, "2")
+	handler.GetUser(w, reqWithUserIDParam(req, "2"))
 
 	if w.Code != http.StatusForbidden {
 		t.Errorf("Expected status 403 for non-admin, got %d", w.Code)
@@ -385,7 +386,7 @@ func TestUpdateUserRole_PermissionCheck_AdminAllowed(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	handler.UpdateUserRole(w, req, "2")
+	handler.UpdateUserRole(w, reqWithUserIDParam(req, "2"))
 
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status 200 for admin, got %d", w.Code)
@@ -427,7 +428,7 @@ func TestUpdateUserRole_PermissionCheck_NonAdminDenied(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	handler.UpdateUserRole(w, req, "2")
+	handler.UpdateUserRole(w, reqWithUserIDParam(req, "2"))
 
 	if w.Code != http.StatusForbidden {
 		t.Errorf("Expected status 403 for non-admin, got %d", w.Code)
@@ -468,7 +469,7 @@ func TestDeleteUser_PermissionCheck_AdminAllowed(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	handler.DeleteUser(w, req, "2")
+	handler.DeleteUser(w, reqWithUserIDParam(req, "2"))
 
 	if w.Code != http.StatusNoContent {
 		t.Errorf("Expected status 204 for admin, got %d", w.Code)
@@ -509,9 +510,17 @@ func TestDeleteUser_PermissionCheck_NonAdminDenied(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	handler.DeleteUser(w, req, "2")
+	handler.DeleteUser(w, reqWithUserIDParam(req, "2"))
 
 	if w.Code != http.StatusForbidden {
 		t.Errorf("Expected status 403 for non-admin, got %d", w.Code)
 	}
+}
+
+// reqWithUserIDParam adds a chi URL parameter "id" to the request so
+// handlers can read it via chi.URLParam(r, "id").
+func reqWithUserIDParam(r *http.Request, userID string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", userID)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
 }

--- a/internal/handlers/users_test.go
+++ b/internal/handlers/users_test.go
@@ -283,7 +283,7 @@ func TestGetUser(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/api/users/"+tt.userID, nil)
 			w := httptest.NewRecorder()
 
-			handler.GetUser(w, req, tt.userID)
+			handler.GetUser(w, reqWithUserIDParam(req, tt.userID))
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("Expected status %d, got %d", tt.wantStatus, w.Code)
@@ -428,7 +428,7 @@ func TestUpdateUserRole(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPatch, "/api/users/"+tt.userID+"/role", bytes.NewReader(body))
 			w := httptest.NewRecorder()
 
-			handler.UpdateUserRole(w, req, tt.userID)
+			handler.UpdateUserRole(w, reqWithUserIDParam(req, tt.userID))
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("Expected status %d, got %d", tt.wantStatus, w.Code)
@@ -544,7 +544,7 @@ func TestDeleteUser(t *testing.T) {
 			req := httptest.NewRequest(http.MethodDelete, "/api/users/"+tt.userID, nil)
 			w := httptest.NewRecorder()
 
-			handler.DeleteUser(w, req, tt.userID)
+			handler.DeleteUser(w, reqWithUserIDParam(req, tt.userID))
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("Expected status %d, got %d", tt.wantStatus, w.Code)
@@ -765,7 +765,7 @@ func TestGetUser_WithAuthorizationCheck(t *testing.T) {
 			req = req.WithContext(ctx)
 			w := httptest.NewRecorder()
 
-			handler.GetUser(w, req, "1")
+			handler.GetUser(w, reqWithUserIDParam(req, "1"))
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("Expected status %d, got %d", tt.wantStatus, w.Code)
@@ -832,7 +832,7 @@ func TestUpdateUserRole_WithAuthorizationCheck(t *testing.T) {
 			req = req.WithContext(ctx)
 			w := httptest.NewRecorder()
 
-			handler.UpdateUserRole(w, req, "1")
+			handler.UpdateUserRole(w, reqWithUserIDParam(req, "1"))
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("Expected status %d, got %d", tt.wantStatus, w.Code)
@@ -895,7 +895,7 @@ func TestDeleteUser_WithAuthorizationCheck(t *testing.T) {
 			req = req.WithContext(ctx)
 			w := httptest.NewRecorder()
 
-			handler.DeleteUser(w, req, "1")
+			handler.DeleteUser(w, reqWithUserIDParam(req, "1"))
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("Expected status %d, got %d", tt.wantStatus, w.Code)

--- a/tests/e2e/auth_flow_test.go
+++ b/tests/e2e/auth_flow_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/lenaxia/tinyrsvp/internal/auth"
 	"github.com/lenaxia/tinyrsvp/internal/db"
 	"github.com/lenaxia/tinyrsvp/internal/db/repositories"
@@ -81,19 +82,18 @@ func setupTestServer(t *testing.T) *testServer {
 		parts := strings.Split(path, "/")
 		userID := parts[0]
 
+		// Set chi URL param so handlers can read it via chi.URLParam(r, "id")
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("id", userID)
+		r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
 		switch r.Method {
 		case http.MethodGet:
-			requireAuth(requireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				userHandler.GetUser(w, r, userID)
-			}))).ServeHTTP(w, r)
+			requireAuth(requireAdmin(http.HandlerFunc(userHandler.GetUser))).ServeHTTP(w, r)
 		case http.MethodPatch:
-			requireAuth(requireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				userHandler.UpdateUserRole(w, r, userID)
-			}))).ServeHTTP(w, r)
+			requireAuth(requireAdmin(http.HandlerFunc(userHandler.UpdateUserRole))).ServeHTTP(w, r)
 		case http.MethodDelete:
-			requireAuth(requireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				userHandler.DeleteUser(w, r, userID)
-			}))).ServeHTTP(w, r)
+			requireAuth(requireAdmin(http.HandlerFunc(userHandler.DeleteUser))).ServeHTTP(w, r)
 		default:
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}


### PR DESCRIPTION
## Summary

Replaces the hand-rolled path-parsing routing for /api/users with proper chi routes. Eliminates ~60 lines of manual path splitting, _method override handling, and per-method auth middleware wrapping.

## Changes

**Before** (60 lines of boilerplate):
- Manual path parsing: strings.TrimPrefix, strings.Split
- Manual _method override: ParseForm, FormValue, strings.ToUpper
- Per-method auth wrapping: RequireAuth(RequireAdmin(http.HandlerFunc(...))) repeated 3 times
- Switch on method with default case

**After** (20 lines of chi routes):
```go
r.Route("/api/users", func(r chi.Router) {
    r.Use(AuthMiddleware.RequireAuth)
    r.Use(AuthMiddleware.RequireAdmin)
    r.Use(methodOverrideMiddleware)
    r.Get("/", ListUsers)
    r.Get("/{id}", GetUser)
    r.Patch("/{id}", UpdateUserRole)
    r.Delete("/{id}", DeleteUser)
})
```

Handler signatures changed to match chi convention: GetUser, UpdateUserRole, DeleteUser now take (w, r) only and read userID from chi.URLParam(r, "id") — same pattern used by all other handlers (events, invites, etc.).

## Validation
- go vet, go build, full non-UX suite — all pass