### PR TITLE
refactor: page handlers use HandleError for primary failures (G13)

### DIFF
--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"html/template"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -54,11 +55,8 @@ func (h *AdminDashboardHandler) AdminDashboard(w http.ResponseWriter, r *http.Re
 
 	stats, err := h.service.GetAdminStats(r.Context())
 	if err != nil {
-		h.renderPage(w, http.StatusOK, &AdminDashboardPageData{
-			ActivePage: "admin",
-			User:       user,
-			Error:      "Failed to load admin statistics",
-		})
+		log.Printf("Admin dashboard: failed to load stats: %v", err)
+		HandleError(w, r, err)
 		return
 	}
 
@@ -166,16 +164,14 @@ func (h *UserManagementHandler) UserManagementPage(w http.ResponseWriter, r *htt
 
 	users, err := h.service.ListUsers(r.Context(), limit, offset)
 	if err != nil {
-		h.renderPage(w, http.StatusOK, &UserManagementPageData{
-			ActivePage: "admin",
-			User:       user,
-			Error:      "Failed to load users",
-		})
+		log.Printf("User management: failed to load users: %v", err)
+		HandleError(w, r, err)
 		return
 	}
 
 	total, err := h.service.CountUsers(r.Context())
 	if err != nil {
+		log.Printf("User management: failed to get user count: %v", err)
 		h.renderPage(w, http.StatusOK, &UserManagementPageData{
 			ActivePage: "admin",
 			User:       user,

--- a/internal/handlers/admin_test.go
+++ b/internal/handlers/admin_test.go
@@ -82,8 +82,8 @@ func TestAdminDashboardHandler_ServiceError(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler.AdminDashboard(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status 200 (renders error state), got %d", w.Code)
+	if w.Code == http.StatusOK {
+		t.Error("Expected non-200 status for primary stats failure (should use HandleError)")
 	}
 }
 
@@ -158,8 +158,8 @@ func TestUserManagementHandler_ServiceError(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler.UserManagementPage(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status 200 (renders error state), got %d", w.Code)
+	if w.Code == http.StatusOK {
+		t.Error("Expected non-200 status for primary list failure (should use HandleError)")
 	}
 }
 

--- a/internal/handlers/dashboard.go
+++ b/internal/handlers/dashboard.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"html/template"
+	"log"
 	"net/http"
 
 	"github.com/lenaxia/tinyrsvp/internal/auth"
@@ -46,16 +47,14 @@ func (h *DashboardHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 
 	stats, err := h.service.GetDashboardStats(r.Context(), user.ID)
 	if err != nil {
-		h.renderPage(w, http.StatusOK, &DashboardPageData{
-			ActivePage: "dashboard",
-			User:       user,
-			Error:      "Failed to load dashboard statistics",
-		})
+		log.Printf("Dashboard: failed to load stats for user %d: %v", user.ID, err)
+		HandleError(w, r, err)
 		return
 	}
 
 	activity, err := h.service.GetRecentActivity(r.Context(), user.ID, 10)
 	if err != nil {
+		log.Printf("Dashboard: failed to load recent activity for user %d: %v", user.ID, err)
 		h.renderPage(w, http.StatusOK, &DashboardPageData{
 			ActivePage: "dashboard",
 			User:       user,

--- a/internal/handlers/dashboard_test.go
+++ b/internal/handlers/dashboard_test.go
@@ -116,8 +116,10 @@ func TestDashboardHandler_Dashboard_StatsError(t *testing.T) {
 
 	handler.Dashboard(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	// Primary data load failure now uses HandleError (returns proper
+	// error status, not HTTP 200 with in-page error).
+	if w.Code == http.StatusOK {
+		t.Error("expected non-200 status for primary stats failure, got 200 (should use HandleError)")
 	}
 }
 

--- a/internal/handlers/events_web.go
+++ b/internal/handlers/events_web.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"html/template"
+	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -111,10 +112,8 @@ func (h *EventWebHandlers) ListEventsPage(w http.ResponseWriter, r *http.Request
 
 	eventList, err := h.service.ListEventsWithStats(r.Context(), filters)
 	if err != nil {
-		h.renderListPage(w, http.StatusOK, &EventListPageData{
-			ActivePage: "events",
-			Error:      "Failed to load events",
-		})
+		log.Printf("Event list: failed to load events: %v", err)
+		HandleError(w, r, err)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Page handlers (dashboard, admin, events_web) were swallowing service errors as HTTP 200 with in-page error text — inconsistent with API handlers that use `HandleError` for proper status codes.

## Approach

**Primary data load failures** (page can't render at all): now use `HandleError` → returns proper HTTP status (500 for internal errors, 404 for not found).

**Secondary data load failures** (page renders with partial data): keep the partial-render pattern but add `log.Printf` so errors are visible in logs instead of silently swallowed.

## Changes

| Handler | Primary failure | Secondary failure |
|---|---|---|
| DashboardHandler | Stats → `HandleError` | Activity → partial render + log |
| AdminDashboardHandler | Stats → `HandleError` | N/A |
| UserManagementHandler | List → `HandleError` | Count → partial render + log |
| EventWebHandlers.ListEventsPage | List → `HandleError` | N/A |

Updated 3 tests to expect non-200 status for primary failures.

## Validation
- `go vet`, `go build`, full non-UX suite — all pass