### PR TITLE
refactor: dashboard stats via SQL aggregation instead of in-memory scan (G2)

### DIFF
--- a/docs/01_WORKLOG/0170_2026-07-08_g2_dashboard_sql_aggregation.md
+++ b/docs/01_WORKLOG/0170_2026-07-08_g2_dashboard_sql_aggregation.md
@@ -1,0 +1,54 @@
+# Worklog 0170: Dashboard Stats via SQL Aggregation (G2)
+
+**Date:** 2026-07-08  
+**Epic:** 10 (Technical Debt)  
+**Branch:** `cleanup/G2-dashboard-sql-aggregation`
+
+---
+
+## Summary
+
+Replaced the dashboard's in-memory stats computation (load ALL events + ALL invites + ALL RSVPs, iterate in Go to count) with a single SQL query using LEFT JOINs and COUNT(DISTINCT CASE WHEN ...). Eliminates one of two full-table scans per dashboard page load.
+
+## Root Cause
+
+`GetDashboardStats` loaded all user events, all invites for those events, and all RSVPs for those invites into memory, then iterated in Go to count by status. This ran on every dashboard page load and was O(total user data).
+
+`GetRecentActivity` does the same full-table scan and is NOT fixed in this PR — it needs the actual event/invite/RSVP records (not just counts) to build activity items. That's a separate optimization.
+
+## Fix
+
+Added `GetDashboardStatsByCreator(ctx, creatorID)` to the event repository:
+
+```sql
+SELECT
+    COUNT(DISTINCT e.id) AS total_events,
+    COUNT(DISTINCT CASE WHEN e.status = 'draft' THEN e.id END) AS draft_events,
+    COUNT(DISTINCT CASE WHEN e.status = 'published' THEN e.id END) AS published_events,
+    COUNT(DISTINCT i.id) AS total_invites,
+    COUNT(DISTINCT CASE WHEN i.status = 'draft' OR i.status = 'sent' THEN i.id END) AS pending_invites,
+    COUNT(DISTINCT rsvp.id) AS total_rsvps,
+    COUNT(DISTINCT CASE WHEN rsvp.response = 'yes' THEN rsvp.id END) AS accepted_rsvps,
+    COUNT(DISTINCT CASE WHEN rsvp.response = 'no' THEN rsvp.id END) AS declined_rsvps
+FROM events e
+LEFT JOIN invites i ON e.id = i.event_id
+LEFT JOIN rsvps rsvp ON i.id = rsvp.invite_id
+WHERE e.created_by = ? AND e.status != 'archived'
+```
+
+Single query, O(1) round-trips regardless of data volume.
+
+## Changes
+
+- `models/event.go`: moved `DashboardStats` struct + `CalculateResponseRate` here (from `events/dashboard_service.go`) to avoid import cycle between `events` and `repositories`
+- `events/dashboard_service.go`: `DashboardStats` is now a type alias for `models.DashboardStats`; `GetDashboardStats` delegates to `eventRepo.GetDashboardStatsByCreator`
+- `repositories/event_repository.go`: added `GetDashboardStatsByCreator` to interface + SQL implementation
+- Updated all local mock EventRepository implementations (7 files) with stub
+- Regenerated `MockEventRepository` via mockgen
+- Updated dashboard service tests to mock the new method
+- Added `TestEventRepository_GetDashboardStatsByCreator` integration test
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** Full suite green

--- a/internal/db/repositories/event_repository.go
+++ b/internal/db/repositories/event_repository.go
@@ -27,6 +27,7 @@ type EventRepository interface {
 	GetByStatus(ctx context.Context, status models.EventStatus) ([]*models.Event, error)
 	GetEventsToArchive(ctx context.Context, daysAfterEvent int) ([]*models.Event, error)
 	GetByCreatorID(ctx context.Context, creatorID int64) ([]*models.Event, error)
+	GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error)
 	CountEvents(ctx context.Context) (int, error)
 	GetComponentOverrides(ctx context.Context, eventID int64) (*models.ComponentOverrides, error)
 	UpdateComponentOverrides(ctx context.Context, eventID int64, overrides *models.ComponentOverrides) error
@@ -826,6 +827,41 @@ func isForeignKeyConstraintError(err error) bool {
 	errMsg := err.Error()
 	return strings.Contains(errMsg, "FOREIGN KEY constraint failed") ||
 		strings.Contains(errMsg, "foreign key constraint")
+}
+
+func (r *eventRepository) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
+	query := `
+		SELECT
+			COUNT(DISTINCT e.id) AS total_events,
+			COUNT(DISTINCT CASE WHEN e.status = 'draft' THEN e.id END) AS draft_events,
+			COUNT(DISTINCT CASE WHEN e.status = 'published' THEN e.id END) AS published_events,
+			COUNT(DISTINCT i.id) AS total_invites,
+			COUNT(DISTINCT CASE WHEN i.status = 'draft' OR i.status = 'sent' THEN i.id END) AS pending_invites,
+			COUNT(DISTINCT rsvp.id) AS total_rsvps,
+			COUNT(DISTINCT CASE WHEN rsvp.response = 'yes' THEN rsvp.id END) AS accepted_rsvps,
+			COUNT(DISTINCT CASE WHEN rsvp.response = 'no' THEN rsvp.id END) AS declined_rsvps
+		FROM events e
+		LEFT JOIN invites i ON e.id = i.event_id
+		LEFT JOIN rsvps rsvp ON i.id = rsvp.invite_id
+		WHERE e.created_by = ? AND e.status != 'archived'
+	`
+
+	stats := &models.DashboardStats{}
+	err := r.db.QueryRow(ctx, query, creatorID).Scan(
+		&stats.TotalEvents,
+		&stats.DraftEvents,
+		&stats.PublishedEvents,
+		&stats.TotalInvites,
+		&stats.PendingInvites,
+		&stats.TotalRSVPs,
+		&stats.AcceptedRSVPs,
+		&stats.DeclinedRSVPs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dashboard stats: %w", err)
+	}
+
+	return stats, nil
 }
 
 func (r *eventRepository) CountEvents(ctx context.Context) (int, error) {

--- a/internal/db/repositories/event_repository_test.go
+++ b/internal/db/repositories/event_repository_test.go
@@ -1474,3 +1474,85 @@ func TestEventRepository_ListWithStats(t *testing.T) {
 		t.Errorf("Status filter: expected 1 event, got %d", len(filtered))
 	}
 }
+
+func TestEventRepository_GetDashboardStatsByCreator(t *testing.T) {
+	database := setupEventTestDB(t)
+	defer database.Close()
+
+	repo := NewEventRepository(database)
+	ctx := context.Background()
+
+	event1 := &models.Event{
+		Title: "Published Event", StartTime: time.Now().Add(24 * time.Hour),
+		Timezone: "UTC", Status: models.EventStatusPublished, CreatedBy: 1,
+	}
+	event2 := &models.Event{
+		Title: "Draft Event", StartTime: time.Now().Add(48 * time.Hour),
+		Timezone: "UTC", Status: models.EventStatusDraft, CreatedBy: 1,
+	}
+	if err := repo.Create(ctx, event1); err != nil {
+		t.Fatalf("create event1: %v", err)
+	}
+	if err := repo.Create(ctx, event2); err != nil {
+		t.Fatalf("create event2: %v", err)
+	}
+
+	_, err := database.Exec(ctx, `
+		INSERT INTO invites (event_id, email, token, token_hash, max_plus_ones, status, created_at, updated_at, expires_at)
+		VALUES
+		  (?, 'a@test.com', 't1', 'h1', 0, 'sent', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + 86400),
+		  (?, 'b@test.com', 't2', 'h2', 0, 'viewed', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + 86400),
+		  (?, 'c@test.com', 't3', 'h3', 0, 'revoked', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + 86400)
+	`, event1.ID, event1.ID, event2.ID)
+	if err != nil {
+		t.Fatalf("create invites: %v", err)
+	}
+
+	_, err = database.Exec(ctx, `
+		INSERT INTO rsvps (invite_id, response, plus_ones, created_at, updated_at)
+		VALUES
+		  (1, 'yes', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		  (2, 'no', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`)
+	if err != nil {
+		t.Fatalf("create rsvps: %v", err)
+	}
+
+	stats, err := repo.GetDashboardStatsByCreator(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetDashboardStatsByCreator: %v", err)
+	}
+
+	if stats.TotalEvents != 2 {
+		t.Errorf("TotalEvents = %d, want 2", stats.TotalEvents)
+	}
+	if stats.PublishedEvents != 1 {
+		t.Errorf("PublishedEvents = %d, want 1", stats.PublishedEvents)
+	}
+	if stats.DraftEvents != 1 {
+		t.Errorf("DraftEvents = %d, want 1", stats.DraftEvents)
+	}
+	if stats.TotalInvites != 3 {
+		t.Errorf("TotalInvites = %d, want 3", stats.TotalInvites)
+	}
+	if stats.PendingInvites != 1 {
+		t.Errorf("PendingInvites = %d, want 1 (only 'sent' status)", stats.PendingInvites)
+	}
+	if stats.TotalRSVPs != 2 {
+		t.Errorf("TotalRSVPs = %d, want 2", stats.TotalRSVPs)
+	}
+	if stats.AcceptedRSVPs != 1 {
+		t.Errorf("AcceptedRSVPs = %d, want 1", stats.AcceptedRSVPs)
+	}
+	if stats.DeclinedRSVPs != 1 {
+		t.Errorf("DeclinedRSVPs = %d, want 1", stats.DeclinedRSVPs)
+	}
+
+	emptyStats, err := repo.GetDashboardStatsByCreator(ctx, 999)
+	if err != nil {
+		t.Fatalf("GetDashboardStatsByCreator for non-existent user: %v", err)
+	}
+	if emptyStats.TotalEvents != 0 {
+		t.Errorf("non-existent user: TotalEvents = %d, want 0", emptyStats.TotalEvents)
+	}
+}

--- a/internal/events/dashboard_service.go
+++ b/internal/events/dashboard_service.go
@@ -12,6 +12,7 @@ import (
 
 type DashboardEventRepository interface {
 	GetByCreatorID(ctx context.Context, creatorID int64) ([]*models.Event, error)
+	GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*DashboardStats, error)
 }
 
 type DashboardInviteRepository interface {
@@ -22,25 +23,7 @@ type DashboardRSVPRepository interface {
 	GetByInviteIDs(ctx context.Context, inviteIDs []int64) ([]*models.RSVP, error)
 }
 
-type DashboardStats struct {
-	TotalEvents     int
-	DraftEvents     int
-	PublishedEvents int
-	TotalInvites    int
-	PendingInvites  int
-	TotalRSVPs      int
-	AcceptedRSVPs   int
-	DeclinedRSVPs   int
-	ResponseRate    int
-}
-
-func (s *DashboardStats) CalculateResponseRate() {
-	if s.TotalInvites == 0 {
-		s.ResponseRate = 0
-		return
-	}
-	s.ResponseRate = (s.TotalRSVPs * 100) / s.TotalInvites
-}
+type DashboardStats = models.DashboardStats
 
 type ActivityItem struct {
 	Icon        string
@@ -117,68 +100,13 @@ func (s *dashboardService) GetDashboardStats(ctx context.Context, userID int64) 
 		}
 	}
 
-	events, err := s.eventRepo.GetByCreatorID(ctx, userID)
+	stats, err := s.eventRepo.GetDashboardStatsByCreator(ctx, userID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get events: %w", err)
+		return nil, fmt.Errorf("failed to get dashboard stats: %w", err)
 	}
 
-	stats := &DashboardStats{}
-
-	stats.TotalEvents = len(events)
-	for _, event := range events {
-		switch event.Status {
-		case models.EventStatusDraft:
-			stats.DraftEvents++
-		case models.EventStatusPublished:
-			stats.PublishedEvents++
-		}
-	}
-
-	if len(events) == 0 {
-		stats.CalculateResponseRate()
-		return stats, nil
-	}
-
-	eventIDs := make([]int64, len(events))
-	for i, event := range events {
-		eventIDs[i] = event.ID
-	}
-
-	invites, err := s.inviteRepo.GetByEventIDs(ctx, eventIDs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get invites: %w", err)
-	}
-
-	stats.TotalInvites = len(invites)
-	for _, invite := range invites {
-		if invite.Status == models.InviteStatusDraft || invite.Status == models.InviteStatusSent {
-			stats.PendingInvites++
-		}
-	}
-
-	if len(invites) == 0 {
-		stats.CalculateResponseRate()
-		return stats, nil
-	}
-
-	inviteIDs := make([]int64, len(invites))
-	for i, invite := range invites {
-		inviteIDs[i] = invite.ID
-	}
-
-	rsvps, err := s.rsvpRepo.GetByInviteIDs(ctx, inviteIDs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get rsvps: %w", err)
-	}
-
-	stats.TotalRSVPs = len(rsvps)
-	for _, rsvp := range rsvps {
-		switch rsvp.Response {
-		case models.RSVPResponseYes:
-			stats.AcceptedRSVPs++
-		case models.RSVPResponseNo:
-			stats.DeclinedRSVPs++
-		}
+	if stats == nil {
+		stats = &DashboardStats{}
 	}
 
 	stats.CalculateResponseRate()

--- a/internal/events/dashboard_service_test.go
+++ b/internal/events/dashboard_service_test.go
@@ -16,42 +16,24 @@ func TestDashboardService_GetDashboardStats_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	now := time.Now()
-	events := []*models.Event{
-		{ID: 1, Status: models.EventStatusDraft, CreatedBy: 1, CreatedAt: now},
-		{ID: 2, Status: models.EventStatusPublished, CreatedBy: 1, CreatedAt: now},
-		{ID: 3, Status: models.EventStatusPublished, CreatedBy: 1, CreatedAt: now},
-	}
-
-	invites := []*models.Invite{
-		{ID: 1, EventID: 1, Status: models.InviteStatusDraft},
-		{ID: 2, EventID: 2, Status: models.InviteStatusSent},
-		{ID: 3, EventID: 2, Status: models.InviteStatusViewed},
-		{ID: 4, EventID: 3, Status: models.InviteStatusViewed},
-	}
-
-	rsvps := []*models.RSVP{
-		{ID: 1, InviteID: 2, Response: models.RSVPResponseYes},
-		{ID: 2, InviteID: 3, Response: models.RSVPResponseYes},
-		{ID: 3, InviteID: 4, Response: models.RSVPResponseNo},
+	expectedStats := &models.DashboardStats{
+		TotalEvents:     3,
+		DraftEvents:     1,
+		PublishedEvents: 2,
+		TotalInvites:    4,
+		PendingInvites:  2,
+		TotalRSVPs:      3,
+		AcceptedRSVPs:   2,
+		DeclinedRSVPs:   1,
 	}
 
 	mockEventRepo := repositories.NewMockEventRepository(ctrl)
 	mockInviteRepo := repositories.NewMockInviteRepository(ctrl)
 	mockRSVPRepo := repositories.NewMockRSVPRepository(ctrl)
 
-	// Set expectations
 	mockEventRepo.EXPECT().
-		GetByCreatorID(gomock.Any(), int64(1)).
-		Return(events, nil)
-
-	mockInviteRepo.EXPECT().
-		GetByEventIDs(gomock.Any(), []int64{1, 2, 3}).
-		Return(invites, nil)
-
-	mockRSVPRepo.EXPECT().
-		GetByInviteIDs(gomock.Any(), []int64{1, 2, 3, 4}).
-		Return(rsvps, nil)
+		GetDashboardStatsByCreator(gomock.Any(), int64(1)).
+		Return(expectedStats, nil)
 
 	service := NewDashboardService(mockEventRepo, mockInviteRepo, mockRSVPRepo)
 
@@ -102,8 +84,8 @@ func TestDashboardService_GetDashboardStats_NoEvents(t *testing.T) {
 
 	// Set expectation
 	mockEventRepo.EXPECT().
-		GetByCreatorID(gomock.Any(), int64(1)).
-		Return([]*models.Event{}, nil)
+		GetDashboardStatsByCreator(gomock.Any(), int64(1)).
+		Return(&models.DashboardStats{}, nil)
 
 	service := NewDashboardService(mockEventRepo, mockInviteRepo, mockRSVPRepo)
 

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -1474,3 +1474,7 @@ func TestService_GetEventsToArchive(t *testing.T) {
 		})
 	}
 }
+
+func (m * mockEventRepository) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
+	return &models.DashboardStats{}, nil
+}

--- a/internal/handlers/events_id_resolver_test.go
+++ b/internal/handlers/events_id_resolver_test.go
@@ -211,3 +211,7 @@ func (m *mockEventIDResolverRepo) GetByCreatorID(ctx context.Context, creatorID 
 func (m *mockEventIDResolverRepo) CountEvents(ctx context.Context) (int, error) {
 	return 0, nil
 }
+
+func (m * mockEventIDResolverRepo) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
+	return &models.DashboardStats{}, nil
+}

--- a/internal/handlers/invites_import_permission_test.go
+++ b/internal/handlers/invites_import_permission_test.go
@@ -525,3 +525,7 @@ func (m *mockEventRepository) GetByPublicID(ctx context.Context, publicID string
 func (m *mockEventRepository) GetByFriendlyName(ctx context.Context, friendlyName string) (*models.Event, error) {
 	return nil, nil
 }
+
+func (m * mockEventRepository) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
+	return &models.DashboardStats{}, nil
+}

--- a/internal/handlers/invites_regenerate_test.go
+++ b/internal/handlers/invites_regenerate_test.go
@@ -499,3 +499,7 @@ func (m *mockRegenerateEventRepository) GetByPublicID(ctx context.Context, publi
 func (m *mockRegenerateEventRepository) GetByFriendlyName(ctx context.Context, friendlyName string) (*models.Event, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (m * mockRegenerateEventRepository) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
+	return &models.DashboardStats{}, nil
+}

--- a/internal/handlers/invites_revoke_test.go
+++ b/internal/handlers/invites_revoke_test.go
@@ -577,3 +577,7 @@ func (m *mockRevokeEventRepository) GetByPublicID(ctx context.Context, publicID 
 func (m *mockRevokeEventRepository) GetByFriendlyName(ctx context.Context, friendlyName string) (*models.Event, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (m * mockRevokeEventRepository) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
+	return &models.DashboardStats{}, nil
+}

--- a/internal/handlers/rsvp_mocks_test.go
+++ b/internal/handlers/rsvp_mocks_test.go
@@ -232,3 +232,7 @@ func (m *mockRSVPService) UpdateRSVP(ctx context.Context, token string, req *rsv
 	}
 	return nil, errors.New("not implemented")
 }
+
+func (m * mockRSVPEventRepository) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
+	return &models.DashboardStats{}, nil
+}

--- a/internal/invites/service_individual_test.go
+++ b/internal/invites/service_individual_test.go
@@ -571,3 +571,7 @@ func TestCreateIndividualInvite_MaxPlusOnesExceeded(t *testing.T) {
 		t.Errorf("Expected ValidationError, got %T", err)
 	}
 }
+
+func (m *mockEventRepository) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
+	return &models.DashboardStats{}, nil
+}

--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -46,3 +46,25 @@ type EventWithStats struct {
 	RSVPCount   int `db:"rsvp_count" json:"rsvp_count"`
 	AcceptCount int `db:"accept_count" json:"accept_count"`
 }
+
+// DashboardStats holds aggregated statistics for a user's dashboard.
+// Defined in models to avoid import cycles between events and repositories.
+type DashboardStats struct {
+	TotalEvents     int
+	DraftEvents     int
+	PublishedEvents int
+	TotalInvites    int
+	PendingInvites  int
+	TotalRSVPs      int
+	AcceptedRSVPs   int
+	DeclinedRSVPs   int
+	ResponseRate    int
+}
+
+func (s *DashboardStats) CalculateResponseRate() {
+	if s.TotalInvites == 0 {
+		s.ResponseRate = 0
+		return
+	}
+	s.ResponseRate = (s.TotalRSVPs * 100) / s.TotalInvites
+}

--- a/internal/testutil/mocks/repositories/mock_event_repository.go
+++ b/internal/testutil/mocks/repositories/mock_event_repository.go
@@ -189,6 +189,21 @@ func (mr *MockEventRepositoryMockRecorder) GetComponentOverrides(ctx, eventID an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetComponentOverrides", reflect.TypeOf((*MockEventRepository)(nil).GetComponentOverrides), ctx, eventID)
 }
 
+// GetDashboardStatsByCreator mocks base method.
+func (m *MockEventRepository) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDashboardStatsByCreator", ctx, creatorID)
+	ret0, _ := ret[0].(*models.DashboardStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDashboardStatsByCreator indicates an expected call of GetDashboardStatsByCreator.
+func (mr *MockEventRepositoryMockRecorder) GetDashboardStatsByCreator(ctx, creatorID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDashboardStatsByCreator", reflect.TypeOf((*MockEventRepository)(nil).GetDashboardStatsByCreator), ctx, creatorID)
+}
+
 // GetEventsToArchive mocks base method.
 func (m *MockEventRepository) GetEventsToArchive(ctx context.Context, daysAfterEvent int) ([]*models.Event, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

Replaces the dashboard's in-memory stats computation with a single SQL aggregation query. Eliminates one of two full-table scans per dashboard page load.

## Before

`GetDashboardStats` loaded ALL user events, ALL invites for those events, and ALL RSVPs for those invites into memory, then iterated in Go to count by status. O(total user data) per page load.

## After

Single SQL query with LEFT JOINs and COUNT(DISTINCT CASE WHEN ...):
```sql
SELECT COUNT(DISTINCT e.id), COUNT(DISTINCT CASE WHEN e.status='draft' ...),
       COUNT(DISTINCT i.id), COUNT(DISTINCT CASE WHEN i.status='sent' ...),
       COUNT(DISTINCT rsvp.id), COUNT(DISTINCT CASE WHEN rsvp.response='yes' ...)
FROM events e
LEFT JOIN invites i ON e.id = i.event_id
LEFT JOIN rsvps rsvp ON i.id = rsvp.invite_id
WHERE e.created_by = ? AND e.status != 'archived'
```

O(1) round-trips regardless of data volume.

## Scope

`GetRecentActivity` still does a full-table scan (it needs the actual records, not just counts, to build activity items). That's a separate optimization — this PR fixes the stats path only.

## Changes

- Moved `DashboardStats` to `models` package (avoids import cycle between `events` and `repositories`)
- Added `GetDashboardStatsByCreator` to `EventRepository` interface + SQL implementation
- `events.DashboardStats` is now a type alias for `models.DashboardStats`
- Updated 7 local mock implementations + regenerated gomock mock
- Added `TestEventRepository_GetDashboardStatsByCreator` integration test

## Validation
- `go vet`, `go build`, full non-UX suite — all pass