### PR TITLE
refactor: remove dead DB-backed HMAC secret methods (G12)

### DIFF
--- a/docs/01_WORKLOG/0172_2026-07-08_g12_remove_dead_hmac.md
+++ b/docs/01_WORKLOG/0172_2026-07-08_g12_remove_dead_hmac.md
@@ -1,0 +1,38 @@
+# Worklog 0172: Remove Dead DB-Backed HMAC Secret (G12)
+
+**Date:** 2026-07-08  
+**Epic:** 10 (Technical Debt)  
+**Branch:** `cleanup/G12-remove-dead-hmac-db-secret`
+
+---
+
+## Summary
+
+Removed the unused DB-backed HMAC secret methods (`GetHMACSecret`, `SetHMACSecret`, `generateAndStoreHMACSecret`) from `ConfigRepository`. These were dead code — defined but never called outside of tests.
+
+## Root Cause
+
+The codebase had two sources of truth for the HMAC secret:
+1. **Environment variable** `SECURITY_HMAC_SECRET` → `config.Security.HMACSecretKey` — used by `main.go` for token generation
+2. **Database `config` table** key `"hmac_secret"` → `ConfigRepository.GetHMACSecret()` — **never called in production code**
+
+The DB-backed methods were defined in the repository interface and implemented, but no production code ever called `GetHMACSecret` or `SetHMACSecret`. They existed only in tests and the repository itself (circular: `GetHMACSecret` calls `generateAndStoreHMACSecret` which calls `SetHMACSecret`).
+
+## Fix
+
+Removed from `ConfigRepository`:
+- `GetHMACSecret(ctx) ([]byte, error)` — dead code
+- `SetHMACSecret(ctx, secret []byte) error` — dead code
+- `generateAndStoreHMACSecret(ctx) ([]byte, error)` — private, dead code
+- `const hmacSecretKey = "hmac_secret"` — unused constant
+
+Removed unused imports: `crypto/rand`, `encoding/base64`.
+
+Removed 3 tests that tested the dead methods. Regenerated `MockConfigRepository`.
+
+The HMAC secret now comes exclusively from the `SECURITY_HMAC_SECRET` environment variable, with no DB fallback. This is the correct single source of truth.
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** Full suite green

--- a/internal/db/repositories/config_repository.go
+++ b/internal/db/repositories/config_repository.go
@@ -2,9 +2,7 @@ package repositories
 
 import (
 	"context"
-	"crypto/rand"
 	"database/sql"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -13,15 +11,11 @@ import (
 	"github.com/lenaxia/tinyrsvp/internal/models"
 )
 
-const hmacSecretKey = "hmac_secret"
-
 type ConfigRepository interface {
 	Get(ctx context.Context, key string) (*models.Config, error)
 	Set(ctx context.Context, key, value string) error
 	Delete(ctx context.Context, key string) error
 	GetAll(ctx context.Context) ([]*models.Config, error)
-	GetHMACSecret(ctx context.Context) ([]byte, error)
-	SetHMACSecret(ctx context.Context, secret []byte) error
 }
 
 type configRepository struct {
@@ -132,44 +126,4 @@ func (r *configRepository) GetAll(ctx context.Context) ([]*models.Config, error)
 	}
 
 	return configs, nil
-}
-
-func (r *configRepository) GetHMACSecret(ctx context.Context) ([]byte, error) {
-	config, err := r.Get(ctx, hmacSecretKey)
-	if err != nil {
-		var notFoundErr *models.NotFoundError
-		if errors.As(err, &notFoundErr) {
-			secret, err := r.generateAndStoreHMACSecret(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to generate HMAC secret: %w", err)
-			}
-			return secret, nil
-		}
-		return nil, err
-	}
-
-	secret, err := base64.StdEncoding.DecodeString(config.Value)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode HMAC secret: %w", err)
-	}
-
-	return secret, nil
-}
-
-func (r *configRepository) SetHMACSecret(ctx context.Context, secret []byte) error {
-	encoded := base64.StdEncoding.EncodeToString(secret)
-	return r.Set(ctx, hmacSecretKey, encoded)
-}
-
-func (r *configRepository) generateAndStoreHMACSecret(ctx context.Context) ([]byte, error) {
-	secret := make([]byte, 32)
-	if _, err := rand.Read(secret); err != nil {
-		return nil, fmt.Errorf("failed to generate random secret: %w", err)
-	}
-
-	if err := r.SetHMACSecret(ctx, secret); err != nil {
-		return nil, err
-	}
-
-	return secret, nil
 }

--- a/internal/db/repositories/config_repository_test.go
+++ b/internal/db/repositories/config_repository_test.go
@@ -1,7 +1,6 @@
 package repositories
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -221,111 +220,7 @@ func TestConfigRepository_GetAll(t *testing.T) {
 	})
 }
 
-func TestConfigRepository_GetHMACSecret(t *testing.T) {
-	database := setupTestDB(t)
-	defer database.Close()
 
-	repo := NewConfigRepository(database)
-	ctx := context.Background()
-
-	t.Run("auto-generate HMAC secret on first call", func(t *testing.T) {
-		secret, err := repo.GetHMACSecret(ctx)
-		if err != nil {
-			t.Fatalf("GetHMACSecret() error = %v", err)
-		}
-
-		if len(secret) < 32 {
-			t.Errorf("Expected secret >= 32 bytes, got %d", len(secret))
-		}
-	})
-
-	t.Run("return same secret on subsequent calls", func(t *testing.T) {
-		secret1, err := repo.GetHMACSecret(ctx)
-		if err != nil {
-			t.Fatalf("GetHMACSecret() error = %v", err)
-		}
-
-		secret2, err := repo.GetHMACSecret(ctx)
-		if err != nil {
-			t.Fatalf("GetHMACSecret() error = %v", err)
-		}
-
-		if !bytes.Equal(secret1, secret2) {
-			t.Error("Expected same secret on subsequent calls")
-		}
-	})
-}
-
-func TestConfigRepository_SetHMACSecret(t *testing.T) {
-	database := setupTestDB(t)
-	defer database.Close()
-
-	repo := NewConfigRepository(database)
-	ctx := context.Background()
-
-	customSecret := []byte("my-custom-secret-that-is-32-bytes-long-exactly!")
-
-	t.Run("set custom HMAC secret", func(t *testing.T) {
-		if err := repo.SetHMACSecret(ctx, customSecret); err != nil {
-			t.Fatalf("SetHMACSecret() error = %v", err)
-		}
-
-		secret, err := repo.GetHMACSecret(ctx)
-		if err != nil {
-			t.Fatalf("GetHMACSecret() error = %v", err)
-		}
-
-		if !bytes.Equal(secret, customSecret) {
-			t.Error("Expected custom secret to be returned")
-		}
-	})
-
-	t.Run("overwrite existing HMAC secret", func(t *testing.T) {
-		newSecret := []byte("another-secret-that-is-also-32-bytes-long-now!")
-
-		if err := repo.SetHMACSecret(ctx, newSecret); err != nil {
-			t.Fatalf("SetHMACSecret() error = %v", err)
-		}
-
-		secret, err := repo.GetHMACSecret(ctx)
-		if err != nil {
-			t.Fatalf("GetHMACSecret() error = %v", err)
-		}
-
-		if !bytes.Equal(secret, newSecret) {
-			t.Error("Expected new secret to be returned")
-		}
-
-		if bytes.Equal(secret, customSecret) {
-			t.Error("Expected old secret to be overwritten")
-		}
-	})
-}
-
-func TestConfigRepository_HMACSecretPersistence(t *testing.T) {
-	database := setupTestDB(t)
-	defer database.Close()
-
-	repo := NewConfigRepository(database)
-	ctx := context.Background()
-
-	t.Run("HMAC secret persists across repository instances", func(t *testing.T) {
-		secret1, err := repo.GetHMACSecret(ctx)
-		if err != nil {
-			t.Fatalf("GetHMACSecret() error = %v", err)
-		}
-
-		newRepo := NewConfigRepository(database)
-		secret2, err := newRepo.GetHMACSecret(ctx)
-		if err != nil {
-			t.Fatalf("GetHMACSecret() error = %v", err)
-		}
-
-		if !bytes.Equal(secret1, secret2) {
-			t.Error("Expected HMAC secret to persist across repository instances")
-		}
-	})
-}
 
 func TestConfigRepository_SetAndGetMultipleKeys(t *testing.T) {
 	database := setupTestDB(t)
@@ -526,32 +421,3 @@ func TestConfigRepository_SpecialCharacters(t *testing.T) {
 	}
 }
 
-func TestConfigRepository_GetHMACSecret_InvalidBase64(t *testing.T) {
-	database := setupTestDB(t)
-	defer database.Close()
-
-	repo := NewConfigRepository(database)
-	ctx := context.Background()
-
-	if err := repo.Set(ctx, "hmac_secret", "invalid-base64!!!"); err != nil {
-		t.Fatalf("Failed to set invalid HMAC secret: %v", err)
-	}
-
-	_, err := repo.GetHMACSecret(ctx)
-	if err == nil {
-		t.Error("Expected error for invalid base64 HMAC secret")
-	}
-
-	if !containsString(err.Error(), "failed to decode HMAC secret") {
-		t.Errorf("Expected decode error, got: %v", err)
-	}
-}
-
-func containsString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/testutil/mocks/repositories/mock_config_repository.go
+++ b/internal/testutil/mocks/repositories/mock_config_repository.go
@@ -85,21 +85,6 @@ func (mr *MockConfigRepositoryMockRecorder) GetAll(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockConfigRepository)(nil).GetAll), ctx)
 }
 
-// GetHMACSecret mocks base method.
-func (m *MockConfigRepository) GetHMACSecret(ctx context.Context) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHMACSecret", ctx)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHMACSecret indicates an expected call of GetHMACSecret.
-func (mr *MockConfigRepositoryMockRecorder) GetHMACSecret(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHMACSecret", reflect.TypeOf((*MockConfigRepository)(nil).GetHMACSecret), ctx)
-}
-
 // Set mocks base method.
 func (m *MockConfigRepository) Set(ctx context.Context, key, value string) error {
 	m.ctrl.T.Helper()
@@ -112,18 +97,4 @@ func (m *MockConfigRepository) Set(ctx context.Context, key, value string) error
 func (mr *MockConfigRepositoryMockRecorder) Set(ctx, key, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockConfigRepository)(nil).Set), ctx, key, value)
-}
-
-// SetHMACSecret mocks base method.
-func (m *MockConfigRepository) SetHMACSecret(ctx context.Context, secret []byte) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetHMACSecret", ctx, secret)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetHMACSecret indicates an expected call of SetHMACSecret.
-func (mr *MockConfigRepositoryMockRecorder) SetHMACSecret(ctx, secret any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHMACSecret", reflect.TypeOf((*MockConfigRepository)(nil).SetHMACSecret), ctx, secret)
 }


### PR DESCRIPTION
## Summary

Removed unused // from . These were dead code — defined but never called in production. The HMAC secret comes exclusively from the  environment variable.

## Root Cause

Two sources of truth existed for the HMAC secret:
1. **Env var**  →  — actually used by 
2. **DB  table** key  →  — **never called in production**

The DB methods were dead code that created a confusing dual source of truth.

## Changes

- Removed , ,  from interface + implementation
- Removed  constant
- Removed unused imports (, )
- Removed 3 tests for the dead methods
- Regenerated 

Net: **-209 lines** of dead code.

## Validation
- `go vet`, `go build`, full non-UX suite — all pass