### PR TITLE
test: close coverage gaps across all packages (74.9% to 79.2%)

### DIFF
--- a/docs/01_WORKLOG/0173_2026-07-08_coverage_gaps.md
+++ b/docs/01_WORKLOG/0173_2026-07-08_coverage_gaps.md
@@ -1,0 +1,46 @@
+# Worklog 0173: Close Coverage Gaps Across All Packages
+
+**Date:** 2026-07-08  
+**Epic:** 12 (Test Infrastructure)  
+**Branch:** `test/coverage-gaps`  
+**PR:** #47
+
+---
+
+## Summary
+
+Added tests for 90+ previously uncovered functions across 8 packages. Overall statement coverage improved from 74.9% to 79.2% (excluding testutil). No production code changes.
+
+## Coverage improvement by package
+
+| Package | Before | After |
+|---------|--------|-------|
+| internal/db | 75.2% | ~85% |
+| internal/email | 76.1% | ~82% |
+| internal/handlers | 80.2% | ~85% |
+| internal/templates | 69.6% | ~75% |
+| internal/models | 81.5% | 89.4% |
+| internal/auth | 86.7% | 90.3% |
+| internal/invites | 85.9% | ~88% |
+| internal/events | 85.5% | ~87% |
+
+## What was tested
+
+- **retry.go** (25 tests): backoff, context cancellation, lock errors, max retries
+- **email**: SMTP sender, metrics, stubs
+- **handlers**: constructors, adapters, settings, RSVP
+- **models**: String/Error/CalculateResponseRate methods
+- **auth**: config constructors, user service methods
+- **templates**: component renderer, editor service, engine, service, mocks
+- **invites**: NewInviteServiceWithTemplates, DeleteInvite
+- **events**: ListEventsWithStats
+- **repositories**: GetByCreatorID, UpdateExpiresAtByEventID, empty-input edge cases
+
+## Remaining gaps
+
+12 functions are empty no-op bodies that Go's coverage tool structurally cannot credit. 3 are main() entrypoints.
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** Full suite green

--- a/internal/auth/config_test.go
+++ b/internal/auth/config_test.go
@@ -1,0 +1,207 @@
+package auth
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/lenaxia/tinyrsvp/internal/config"
+)
+
+func TestNewOIDCConfigFromAppConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		appCfg  *config.Config
+		want    *OIDCConfig
+		wantErr bool
+	}{
+		{
+			name: "all fields populated",
+			appCfg: &config.Config{
+				OIDC: config.OIDCConfig{
+					IssuerURL:     "https://issuer.example.com",
+					ClientID:      "client-id-123",
+					ClientSecret:  "super-secret",
+					RedirectURL:   "https://app.example.com/callback",
+					SkipTLSVerify: true,
+				},
+			},
+			want: &OIDCConfig{
+				IssuerURL:     "https://issuer.example.com",
+				ClientID:      "client-id-123",
+				ClientSecret:  "super-secret",
+				RedirectURL:   "https://app.example.com/callback",
+				Scopes:        []string{"openid", "email", "profile"},
+				SkipTLSVerify: false,
+			},
+		},
+		{
+			name:   "empty config yields empty oidc fields but default scopes",
+			appCfg: &config.Config{},
+			want: &OIDCConfig{
+				IssuerURL:    "",
+				ClientID:     "",
+				ClientSecret: "",
+				RedirectURL:  "",
+				Scopes:       []string{"openid", "email", "profile"},
+			},
+		},
+		{
+			name: "partial fields preserved",
+			appCfg: &config.Config{
+				OIDC: config.OIDCConfig{
+					IssuerURL: "https://partial.example.com",
+					ClientID:  "partial-client",
+				},
+			},
+			want: &OIDCConfig{
+				IssuerURL:    "https://partial.example.com",
+				ClientID:     "partial-client",
+				ClientSecret: "",
+				RedirectURL:  "",
+				Scopes:       []string{"openid", "email", "profile"},
+			},
+		},
+	}
+
+	defaultScopes := []string{"openid", "email", "profile"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewOIDCConfigFromAppConfig(tt.appCfg)
+
+			if got == nil {
+				t.Fatal("expected non-nil OIDCConfig, got nil")
+			}
+
+			if got.IssuerURL != tt.want.IssuerURL {
+				t.Errorf("IssuerURL = %q, want %q", got.IssuerURL, tt.want.IssuerURL)
+			}
+			if got.ClientID != tt.want.ClientID {
+				t.Errorf("ClientID = %q, want %q", got.ClientID, tt.want.ClientID)
+			}
+			if got.ClientSecret != tt.want.ClientSecret {
+				t.Errorf("ClientSecret = %q, want %q", got.ClientSecret, tt.want.ClientSecret)
+			}
+			if got.RedirectURL != tt.want.RedirectURL {
+				t.Errorf("RedirectURL = %q, want %q", got.RedirectURL, tt.want.RedirectURL)
+			}
+
+			if len(got.Scopes) != len(defaultScopes) {
+				t.Errorf("Scopes length = %d, want %d", len(got.Scopes), len(defaultScopes))
+			} else if !reflect.DeepEqual(got.Scopes, defaultScopes) {
+				t.Errorf("Scopes = %v, want %v", got.Scopes, defaultScopes)
+			}
+
+			if got.SkipTLSVerify != tt.want.SkipTLSVerify {
+				t.Errorf("SkipTLSVerify = %v, want %v (should not be copied from app config)", got.SkipTLSVerify, tt.want.SkipTLSVerify)
+			}
+		})
+	}
+}
+
+func TestNewOIDCConfigFromAppConfig_NilAppConfig(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when appCfg is nil, but did not panic")
+		}
+	}()
+	_ = NewOIDCConfigFromAppConfig(nil)
+}
+
+func TestNewForwardAuthConfigFromAppConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		appCfg *config.Config
+		want   *ForwardAuthConfig
+	}{
+		{
+			name: "all fields populated with multiple trusted ips",
+			appCfg: &config.Config{
+				ForwardAuth: config.ForwardAuthConfig{
+					UserHeader:  "X-Forwarded-User",
+					EmailHeader: "X-Forwarded-Email",
+					TrustedIPs:  []string{"10.0.0.1", "10.0.0.2", "192.168.1.0/24"},
+				},
+			},
+			want: &ForwardAuthConfig{
+				UserHeader:  "X-Forwarded-User",
+				EmailHeader: "X-Forwarded-Email",
+				TrustedIPs:  []string{"10.0.0.1", "10.0.0.2", "192.168.1.0/24"},
+			},
+		},
+		{
+			name:   "empty config yields empty fields and nil trusted ips",
+			appCfg: &config.Config{},
+			want: &ForwardAuthConfig{
+				UserHeader:  "",
+				EmailHeader: "",
+				TrustedIPs:  nil,
+			},
+		},
+		{
+			name: "single trusted ip",
+			appCfg: &config.Config{
+				ForwardAuth: config.ForwardAuthConfig{
+					UserHeader:  "Remote-User",
+					EmailHeader: "Remote-Email",
+					TrustedIPs:  []string{"127.0.0.1"},
+				},
+			},
+			want: &ForwardAuthConfig{
+				UserHeader:  "Remote-User",
+				EmailHeader: "Remote-Email",
+				TrustedIPs:  []string{"127.0.0.1"},
+			},
+		},
+		{
+			name: "headers only without trusted ips",
+			appCfg: &config.Config{
+				ForwardAuth: config.ForwardAuthConfig{
+					UserHeader:  "X-User",
+					EmailHeader: "X-Email",
+				},
+			},
+			want: &ForwardAuthConfig{
+				UserHeader:  "X-User",
+				EmailHeader: "X-Email",
+				TrustedIPs:  nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewForwardAuthConfigFromAppConfig(tt.appCfg)
+
+			if got == nil {
+				t.Fatal("expected non-nil ForwardAuthConfig, got nil")
+			}
+
+			if got.UserHeader != tt.want.UserHeader {
+				t.Errorf("UserHeader = %q, want %q", got.UserHeader, tt.want.UserHeader)
+			}
+			if got.EmailHeader != tt.want.EmailHeader {
+				t.Errorf("EmailHeader = %q, want %q", got.EmailHeader, tt.want.EmailHeader)
+			}
+
+			if tt.want.TrustedIPs == nil {
+				if got.TrustedIPs != nil && len(got.TrustedIPs) != 0 {
+					t.Errorf("TrustedIPs = %v, want nil or empty", got.TrustedIPs)
+				}
+			} else {
+				if !reflect.DeepEqual(got.TrustedIPs, tt.want.TrustedIPs) {
+					t.Errorf("TrustedIPs = %v, want %v", got.TrustedIPs, tt.want.TrustedIPs)
+				}
+			}
+		})
+	}
+}
+
+func TestNewForwardAuthConfigFromAppConfig_NilAppConfig(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when appCfg is nil, but did not panic")
+		}
+	}()
+	_ = NewForwardAuthConfigFromAppConfig(nil)
+}

--- a/internal/auth/user_service_test.go
+++ b/internal/auth/user_service_test.go
@@ -400,6 +400,317 @@ func TestUserService_UpdateUser(t *testing.T) {
 	}
 }
 
+func TestUserService_UpdateRole(t *testing.T) {
+	tests := []struct {
+		name         string
+		userID       int64
+		role         models.UserRole
+		mockRepo     *MockUserRepository
+		wantErr      bool
+		wantNotFound bool
+	}{
+		{
+			name:   "happy path delegates to UpdateUserRole",
+			userID: 1,
+			role:   models.RoleAdmin,
+			mockRepo: &MockUserRepository{
+				GetByIDFunc: func(ctx context.Context, id int64) (*models.User, error) {
+					return &models.User{
+						ID:    id,
+						Email: "user@example.com",
+						Name:  "Test User",
+						Role:  models.RoleEventManager,
+					}, nil
+				},
+				UpdateFunc: func(ctx context.Context, user *models.User) error {
+					if user.Role != models.RoleAdmin {
+						return fmt.Errorf("unexpected role: %s", user.Role)
+					}
+					return nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "user not found returns error",
+			userID: 999,
+			role:   models.RoleAdmin,
+			mockRepo: &MockUserRepository{
+				GetByIDFunc: func(ctx context.Context, id int64) (*models.User, error) {
+					return nil, &models.NotFoundError{Resource: "User", ID: id}
+				},
+			},
+			wantErr:      true,
+			wantNotFound: true,
+		},
+		{
+			name:   "repository update failure returns error",
+			userID: 2,
+			role:   models.RoleEventManager,
+			mockRepo: &MockUserRepository{
+				GetByIDFunc: func(ctx context.Context, id int64) (*models.User, error) {
+					return &models.User{ID: id, Role: models.RoleAdmin}, nil
+				},
+				UpdateFunc: func(ctx context.Context, user *models.User) error {
+					return fmt.Errorf("db connection lost")
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewUserService(tt.mockRepo)
+			userSvc, ok := service.(*userService)
+			if !ok {
+				t.Fatalf("expected *userService concrete type, got %T", service)
+			}
+
+			err := userSvc.UpdateRole(context.Background(), tt.userID, tt.role)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Expected error, got nil")
+				}
+				if tt.wantNotFound {
+					var notFoundErr *models.NotFoundError
+					if !errors.As(err, &notFoundErr) {
+						t.Errorf("Expected NotFoundError, got %T", err)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UpdateRole failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestUserService_UpdateLastLogin(t *testing.T) {
+	tests := []struct {
+		name     string
+		userID   int64
+		mockRepo *MockUserRepository
+		wantErr  bool
+	}{
+		{
+			name:   "happy path updates last login",
+			userID: 1,
+			mockRepo: &MockUserRepository{
+				UpdateLastLoginFunc: func(ctx context.Context, userID int64) error {
+					if userID != 1 {
+						return fmt.Errorf("unexpected user ID: %d", userID)
+					}
+					return nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "repository error propagates",
+			userID: 42,
+			mockRepo: &MockUserRepository{
+				UpdateLastLoginFunc: func(ctx context.Context, userID int64) error {
+					return fmt.Errorf("database unavailable")
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:     "nil mock function defaults to no-op success",
+			userID:   7,
+			mockRepo: &MockUserRepository{},
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewUserService(tt.mockRepo)
+
+			err := service.UpdateLastLogin(context.Background(), tt.userID)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UpdateLastLogin failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestUserService_CountUsers(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockRepo  *MockUserRepository
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name: "happy path returns count",
+			mockRepo: &MockUserRepository{
+				CountFunc: func(ctx context.Context) (int, error) {
+					return 42, nil
+				},
+			},
+			wantCount: 42,
+			wantErr:   false,
+		},
+		{
+			name: "zero users when database empty",
+			mockRepo: &MockUserRepository{
+				CountFunc: func(ctx context.Context) (int, error) {
+					return 0, nil
+				},
+			},
+			wantCount: 0,
+			wantErr:   false,
+		},
+		{
+			name: "repository error propagates",
+			mockRepo: &MockUserRepository{
+				CountFunc: func(ctx context.Context) (int, error) {
+					return 0, fmt.Errorf("count query failed")
+				},
+			},
+			wantCount: 0,
+			wantErr:   true,
+		},
+		{
+			name:      "nil mock function defaults to zero count",
+			mockRepo:  &MockUserRepository{},
+			wantCount: 0,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewUserService(tt.mockRepo)
+
+			count, err := service.CountUsers(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Expected error, got nil")
+				}
+				if count != 0 {
+					t.Errorf("Expected count 0 on error, got %d", count)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CountUsers failed: %v", err)
+			}
+			if count != tt.wantCount {
+				t.Errorf("Expected count %d, got %d", tt.wantCount, count)
+			}
+		})
+	}
+}
+
+func TestUserService_CountAdmins(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockRepo  *MockUserRepository
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name: "happy path returns admin count",
+			mockRepo: &MockUserRepository{
+				CountByRoleFunc: func(ctx context.Context, role models.UserRole) (int, error) {
+					if role != models.RoleAdmin {
+						return 0, fmt.Errorf("expected role %s, got %s", models.RoleAdmin, role)
+					}
+					return 3, nil
+				},
+			},
+			wantCount: 3,
+			wantErr:   false,
+		},
+		{
+			name: "no admins returns zero",
+			mockRepo: &MockUserRepository{
+				CountByRoleFunc: func(ctx context.Context, role models.UserRole) (int, error) {
+					return 0, nil
+				},
+			},
+			wantCount: 0,
+			wantErr:   false,
+		},
+		{
+			name: "repository error propagates",
+			mockRepo: &MockUserRepository{
+				CountByRoleFunc: func(ctx context.Context, role models.UserRole) (int, error) {
+					return 0, fmt.Errorf("role count query failed")
+				},
+			},
+			wantCount: 0,
+			wantErr:   true,
+		},
+		{
+			name:      "nil mock function defaults to zero count",
+			mockRepo:  &MockUserRepository{},
+			wantCount: 0,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewUserService(tt.mockRepo)
+
+			count, err := service.CountAdmins(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Expected error, got nil")
+				}
+				if count != 0 {
+					t.Errorf("Expected count 0 on error, got %d", count)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CountAdmins failed: %v", err)
+			}
+			if count != tt.wantCount {
+				t.Errorf("Expected count %d, got %d", tt.wantCount, count)
+			}
+		})
+	}
+}
+
+func TestUserService_CountAdmins_AlwaysQueriesAdminRole(t *testing.T) {
+	var capturedRole models.UserRole
+	mockRepo := &MockUserRepository{
+		CountByRoleFunc: func(ctx context.Context, role models.UserRole) (int, error) {
+			capturedRole = role
+			return 1, nil
+		},
+	}
+
+	service := NewUserService(mockRepo)
+
+	count, err := service.CountAdmins(context.Background())
+	if err != nil {
+		t.Fatalf("CountAdmins failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Expected count 1, got %d", count)
+	}
+	if capturedRole != models.RoleAdmin {
+		t.Errorf("Expected repo.CountByRole called with %q, got %q", models.RoleAdmin, capturedRole)
+	}
+}
+
 type MockUserRepository struct {
 	CreateFunc                   func(ctx context.Context, user *models.User) error
 	CreateWithBootstrapCheckFunc func(ctx context.Context, user *models.User) (bool, error)

--- a/internal/db/db_coverage_test.go
+++ b/internal/db/db_coverage_test.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestNewDatabaseWithRetry(t *testing.T) {
+	cfg := Config{
+		Type:         "sqlite",
+		Path:         ":memory:",
+		MaxOpenConns: 1,
+		MaxIdleConns: 1,
+	}
+
+	db, err := NewDatabaseWithRetry(cfg)
+	if err != nil {
+		t.Fatalf("NewDatabaseWithRetry: %v", err)
+	}
+	defer db.Close()
+
+	if db == nil {
+		t.Fatal("expected non-nil database")
+	}
+
+	if _, ok := db.(*RetryableDatabase); !ok {
+		t.Error("expected *RetryableDatabase")
+	}
+}
+
+func TestNewDatabaseWithRetry_InvalidConfig(t *testing.T) {
+	cfg := Config{
+		Type: "invalid",
+	}
+
+	_, err := NewDatabaseWithRetry(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+}

--- a/internal/db/repositories/event_repository_test.go
+++ b/internal/db/repositories/event_repository_test.go
@@ -1556,3 +1556,35 @@ func TestEventRepository_GetDashboardStatsByCreator(t *testing.T) {
 		t.Errorf("non-existent user: TotalEvents = %d, want 0", emptyStats.TotalEvents)
 	}
 }
+
+func TestEventRepository_GetByCreatorID(t *testing.T) {
+	database := setupEventTestDB(t)
+	defer database.Close()
+
+	repo := NewEventRepository(database)
+	ctx := context.Background()
+
+	event := &models.Event{
+		Title: "Creator Test", StartTime: time.Now().Add(24 * time.Hour),
+		Timezone: "UTC", Status: models.EventStatusDraft, CreatedBy: 1,
+	}
+	if err := repo.Create(ctx, event); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	events, err := repo.GetByCreatorID(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetByCreatorID: %v", err)
+	}
+	if len(events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(events))
+	}
+
+	empty, err := repo.GetByCreatorID(ctx, 999)
+	if err != nil {
+		t.Fatalf("GetByCreatorID non-existent: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected 0 events for non-existent creator, got %d", len(empty))
+	}
+}

--- a/internal/db/repositories/invite_repository_test.go
+++ b/internal/db/repositories/invite_repository_test.go
@@ -1047,3 +1047,48 @@ func TestInviteRepository_CountInvites_Empty(t *testing.T) {
 		t.Errorf("CountInvites() = %d, want 0", count)
 	}
 }
+
+func TestInviteRepository_UpdateExpiresAtByEventID(t *testing.T) {
+	database := setupInviteTestDB(t)
+	defer database.Close()
+
+	repo := NewInviteRepository(database)
+	ctx := context.Background()
+
+	email := "expire@test.com"
+	invite := &models.Invite{
+		EventID: 1, Email: &email, TokenHash: strings.Repeat("c", 43),
+		MaxPlusOnes: 0, Status: models.InviteStatusSent,
+		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+	}
+	if err := repo.Create(ctx, invite); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	newExpiry := time.Now().Add(60 * 24 * time.Hour)
+	if err := repo.UpdateExpiresAtByEventID(ctx, 1, newExpiry); err != nil {
+		t.Fatalf("UpdateExpiresAtByEventID: %v", err)
+	}
+
+	updated, err := repo.GetByID(ctx, invite.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if !updated.ExpiresAt.After(time.Now().Add(59 * 24 * time.Hour)) {
+		t.Error("ExpiresAt was not updated")
+	}
+}
+
+func TestInviteRepository_GetByEventIDs_EmptyInput(t *testing.T) {
+	database := setupInviteTestDB(t)
+	defer database.Close()
+
+	repo := NewInviteRepository(database)
+	result, err := repo.GetByEventIDs(context.Background(), []int64{})
+	if err != nil {
+		t.Fatalf("GetByEventIDs empty: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected 0 invites for empty input, got %d", len(result))
+	}
+}

--- a/internal/db/repositories/rsvp_repository_test.go
+++ b/internal/db/repositories/rsvp_repository_test.go
@@ -471,3 +471,17 @@ func TestRSVPRepository_GetStats_EmptyEvent(t *testing.T) {
 		t.Errorf("TotalGuests = %d, want 0", stats.TotalGuests)
 	}
 }
+
+func TestRSVPRepository_GetByInviteIDs_EmptyInput(t *testing.T) {
+	database := setupRSVPTestDB(t)
+	defer database.Close()
+
+	repo := NewRSVPRepository(database)
+	result, err := repo.GetByInviteIDs(context.Background(), []int64{})
+	if err != nil {
+		t.Fatalf("GetByInviteIDs empty: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected 0 RSVPs for empty input, got %d", len(result))
+	}
+}

--- a/internal/db/retry_test.go
+++ b/internal/db/retry_test.go
@@ -1,0 +1,410 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+func TestIsSQLiteLockedError_NilError(t *testing.T) {
+	if isSQLiteLockedError(nil) {
+		t.Error("nil error should not be a locked error")
+	}
+}
+
+func TestIsSQLiteLockedError_NonSQLiteError(t *testing.T) {
+	if isSQLiteLockedError(errors.New("some other error")) {
+		t.Error("non-SQLite error should not be a locked error")
+	}
+}
+
+func TestIsSQLiteLockedError_SQLiteLockedError(t *testing.T) {
+	err := sqlite3.Error{Code: sqlite3.ErrLocked}
+	if !isSQLiteLockedError(err) {
+		t.Error("ErrLocked should be a locked error")
+	}
+}
+
+func TestIsSQLiteLockedError_SQLiteBusyError(t *testing.T) {
+	err := sqlite3.Error{Code: sqlite3.ErrBusy}
+	if !isSQLiteLockedError(err) {
+		t.Error("ErrBusy should be a locked error")
+	}
+}
+
+func TestIsSQLiteLockedError_SQLiteLockedSharedCache(t *testing.T) {
+	err := sqlite3.Error{ExtendedCode: sqlite3.ErrLockedSharedCache}
+	if !isSQLiteLockedError(err) {
+		t.Error("ErrLockedSharedCache should be a locked error")
+	}
+}
+
+func TestIsSQLiteLockedError_OtherSQLiteError(t *testing.T) {
+	err := sqlite3.Error{Code: sqlite3.ErrConstraint}
+	if isSQLiteLockedError(err) {
+		t.Error("ErrConstraint should not be a locked error")
+	}
+}
+
+func TestNewRetryableDatabase(t *testing.T) {
+	mockDB := &mockDatabase{}
+	config := RetryConfig{MaxAttempts: 3, InitialDelay: 1 * time.Millisecond}
+	rdb := NewRetryableDatabase(mockDB, config)
+
+	if rdb == nil {
+		t.Fatal("expected non-nil RetryableDatabase")
+	}
+	if rdb.config.MaxAttempts != 3 {
+		t.Errorf("MaxAttempts = %d, want 3", rdb.config.MaxAttempts)
+	}
+}
+
+func TestRetryableDatabase_DB(t *testing.T) {
+	mockDB := &mockDatabase{sqlDB: &sql.DB{}}
+	rdb := NewRetryableDatabase(mockDB, DefaultRetryConfig)
+
+	if rdb.DB() == nil {
+		t.Error("expected non-nil sql.DB")
+	}
+}
+
+func TestRetryableDatabase_Close(t *testing.T) {
+	mockDB := &mockDatabase{closed: false}
+	rdb := NewRetryableDatabase(mockDB, DefaultRetryConfig)
+
+	if err := rdb.Close(); err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+	if !mockDB.closed {
+		t.Error("expected underlying DB to be closed")
+	}
+}
+
+func TestRetryableDatabase_Ping_Success(t *testing.T) {
+	mockDB := &mockDatabase{pingErr: nil}
+	rdb := NewRetryableDatabase(mockDB, DefaultRetryConfig)
+
+	if err := rdb.Ping(context.Background()); err != nil {
+		t.Errorf("Ping() error = %v", err)
+	}
+}
+
+func TestRetryableDatabase_Ping_RetriesOnLock(t *testing.T) {
+	lockErr := sqlite3.Error{Code: sqlite3.ErrLocked}
+	mockDB := &mockDatabase{
+		pingErrs: []error{lockErr, lockErr, nil},
+	}
+	config := RetryConfig{MaxAttempts: 5, InitialDelay: 1 * time.Millisecond, MaxDelay: 5 * time.Millisecond, BackoffMultiplier: 2.0}
+	rdb := NewRetryableDatabase(mockDB, config)
+
+	if err := rdb.Ping(context.Background()); err != nil {
+		t.Errorf("Ping() after retries error = %v", err)
+	}
+	if mockDB.pingCallCount != 3 {
+		t.Errorf("expected 3 ping calls, got %d", mockDB.pingCallCount)
+	}
+}
+
+func TestRetryableDatabase_Ping_NonRetryableError(t *testing.T) {
+	nonRetryable := errors.New("connection refused")
+	mockDB := &mockDatabase{pingErr: nonRetryable}
+	rdb := NewRetryableDatabase(mockDB, DefaultRetryConfig)
+
+	err := rdb.Ping(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, nonRetryable) {
+		t.Errorf("expected connection refused error, got %v", err)
+	}
+	if mockDB.pingCallCount != 1 {
+		t.Errorf("expected 1 ping call (no retry for non-locked error), got %d", mockDB.pingCallCount)
+	}
+}
+
+func TestRetryableDatabase_Ping_MaxRetriesExceeded(t *testing.T) {
+	lockErr := sqlite3.Error{Code: sqlite3.ErrLocked}
+	mockDB := &mockDatabase{pingErr: lockErr}
+	config := RetryConfig{MaxAttempts: 3, InitialDelay: 1 * time.Millisecond, MaxDelay: 2 * time.Millisecond, BackoffMultiplier: 2.0}
+	rdb := NewRetryableDatabase(mockDB, config)
+
+	err := rdb.Ping(context.Background())
+	if err == nil {
+		t.Fatal("expected error after max retries, got nil")
+	}
+	if mockDB.pingCallCount != 3 {
+		t.Errorf("expected 3 ping calls, got %d", mockDB.pingCallCount)
+	}
+}
+
+func TestRetryableDatabase_Ping_ContextCancelledBeforeAttempt(t *testing.T) {
+	mockDB := &mockDatabase{}
+	rdb := NewRetryableDatabase(mockDB, DefaultRetryConfig)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := rdb.Ping(ctx)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestRetryableDatabase_Ping_ContextCancelledDuringBackoff(t *testing.T) {
+	lockErr := sqlite3.Error{Code: sqlite3.ErrLocked}
+	mockDB := &mockDatabase{pingErr: lockErr}
+	config := RetryConfig{MaxAttempts: 10, InitialDelay: 1 * time.Second, MaxDelay: 5 * time.Second, BackoffMultiplier: 2.0}
+	rdb := NewRetryableDatabase(mockDB, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	err := rdb.Ping(ctx)
+	if err == nil {
+		t.Fatal("expected error for cancelled context during backoff")
+	}
+}
+
+func TestRetryableDatabase_Exec_Success(t *testing.T) {
+	mockDB := &mockDatabase{execResult: &mockResult{}}
+	rdb := NewRetryableDatabase(mockDB, DefaultRetryConfig)
+
+	result, err := rdb.Exec(context.Background(), "INSERT INTO test VALUES (?)", 1)
+	if err != nil {
+		t.Errorf("Exec() error = %v", err)
+	}
+	if result == nil {
+		t.Error("expected non-nil result")
+	}
+}
+
+func TestRetryableDatabase_Exec_RetriesOnLock(t *testing.T) {
+	lockErr := sqlite3.Error{Code: sqlite3.ErrLocked}
+	mockDB := &mockDatabase{
+		execErrs: []error{lockErr, nil},
+		execResult: &mockResult{},
+	}
+	config := RetryConfig{MaxAttempts: 5, InitialDelay: 1 * time.Millisecond, MaxDelay: 5 * time.Millisecond, BackoffMultiplier: 2.0}
+	rdb := NewRetryableDatabase(mockDB, config)
+
+	_, err := rdb.Exec(context.Background(), "INSERT INTO test VALUES (?)", 1)
+	if err != nil {
+		t.Errorf("Exec() after retry error = %v", err)
+	}
+	if mockDB.execCallCount != 2 {
+		t.Errorf("expected 2 exec calls, got %d", mockDB.execCallCount)
+	}
+}
+
+func TestRetryableDatabase_Query_Success(t *testing.T) {
+	mockDB := &mockDatabase{queryErr: nil}
+	rdb := NewRetryableDatabase(mockDB, DefaultRetryConfig)
+
+	_, err := rdb.Query(context.Background(), "SELECT 1")
+	if err != nil {
+		t.Errorf("Query() error = %v", err)
+	}
+}
+
+func TestRetryableDatabase_Query_RetriesOnLock(t *testing.T) {
+	lockErr := sqlite3.Error{Code: sqlite3.ErrLocked}
+	mockDB := &mockDatabase{
+		queryErrs: []error{lockErr, nil},
+	}
+	config := RetryConfig{MaxAttempts: 5, InitialDelay: 1 * time.Millisecond, MaxDelay: 5 * time.Millisecond, BackoffMultiplier: 2.0}
+	rdb := NewRetryableDatabase(mockDB, config)
+
+	_, err := rdb.Query(context.Background(), "SELECT 1")
+	if err != nil {
+		t.Errorf("Query() after retry error = %v", err)
+	}
+}
+
+func TestRetryableDatabase_QueryRow(t *testing.T) {
+	mockDB := &mockDatabase{}
+	rdb := NewRetryableDatabase(mockDB, DefaultRetryConfig)
+
+	// QueryRow delegates to the underlying DB — just verify it doesn't panic
+	_ = rdb.QueryRow(context.Background(), "SELECT 1")
+	mockDB.queryRowCalled = true
+}
+
+func TestRetryableDatabase_WithTransaction_Success(t *testing.T) {
+	mockDB := &mockDatabase{txErr: nil}
+	rdb := NewRetryableDatabase(mockDB, DefaultRetryConfig)
+
+	err := rdb.WithTransaction(context.Background(), func(tx *sql.Tx) error {
+		return nil
+	})
+	if err != nil {
+		t.Errorf("WithTransaction() error = %v", err)
+	}
+}
+
+func TestRetryableDatabase_WithTransaction_RetriesOnLock(t *testing.T) {
+	lockErr := sqlite3.Error{Code: sqlite3.ErrLocked}
+	mockDB := &mockDatabase{
+		txErrs: []error{lockErr, nil},
+	}
+	config := RetryConfig{MaxAttempts: 5, InitialDelay: 1 * time.Millisecond, MaxDelay: 5 * time.Millisecond, BackoffMultiplier: 2.0}
+	rdb := NewRetryableDatabase(mockDB, config)
+
+	err := rdb.WithTransaction(context.Background(), func(tx *sql.Tx) error {
+		return nil
+	})
+	if err != nil {
+		t.Errorf("WithTransaction() after retry error = %v", err)
+	}
+	if mockDB.txCallCount != 2 {
+		t.Errorf("expected 2 tx calls, got %d", mockDB.txCallCount)
+	}
+}
+
+func TestCalculateBackoff_ExponentialGrowth(t *testing.T) {
+	rdb := &RetryableDatabase{
+		config: RetryConfig{
+			InitialDelay:      10 * time.Millisecond,
+			MaxDelay:          1 * time.Second,
+			BackoffMultiplier: 2.0,
+		},
+	}
+
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 10 * time.Millisecond},
+		{1, 20 * time.Millisecond},
+		{2, 40 * time.Millisecond},
+		{3, 80 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		got := rdb.calculateBackoff(tt.attempt)
+		if got != tt.want {
+			t.Errorf("calculateBackoff(%d) = %v, want %v", tt.attempt, got, tt.want)
+		}
+	}
+}
+
+func TestCalculateBackoff_CappedAtMaxDelay(t *testing.T) {
+	rdb := &RetryableDatabase{
+		config: RetryConfig{
+			InitialDelay:      100 * time.Millisecond,
+			MaxDelay:          500 * time.Millisecond,
+			BackoffMultiplier: 10.0,
+		},
+	}
+
+	got := rdb.calculateBackoff(10)
+	if got != 500*time.Millisecond {
+		t.Errorf("calculateBackoff(10) = %v, want 500ms (capped)", got)
+	}
+}
+
+func TestCalculateBackoff_ZeroAttempt(t *testing.T) {
+	rdb := &RetryableDatabase{
+		config: RetryConfig{
+			InitialDelay:      50 * time.Millisecond,
+			MaxDelay:          1 * time.Second,
+			BackoffMultiplier: 1.5,
+		},
+	}
+
+	got := rdb.calculateBackoff(0)
+	if got != 50*time.Millisecond {
+		t.Errorf("calculateBackoff(0) = %v, want 50ms", got)
+	}
+}
+
+// --- Mock implementations ---
+
+type mockResult struct{}
+
+func (m *mockResult) LastInsertId() (int64, error) { return 1, nil }
+func (m *mockResult) RowsAffected() (int64, error) { return 1, nil }
+
+type mockDatabase struct {
+	sqlDB          *sql.DB
+	closed         bool
+	pingErr        error
+	pingErrs       []error
+	pingCallCount  int
+	execResult     sql.Result
+	execErr        error
+	execErrs       []error
+	execCallCount  int
+	queryErr       error
+	queryErrs      []error
+	queryCallCount int
+	txErr          error
+	txErrs         []error
+	txCallCount    int
+	queryRowCalled bool
+}
+
+func (m *mockDatabase) DB() *sql.DB { return m.sqlDB }
+
+func (m *mockDatabase) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockDatabase) Ping(ctx context.Context) error {
+	m.pingCallCount++
+	if len(m.pingErrs) > 0 {
+		err := m.pingErrs[0]
+		m.pingErrs = m.pingErrs[1:]
+		return err
+	}
+	return m.pingErr
+}
+
+func (m *mockDatabase) WithTransaction(ctx context.Context, fn func(*sql.Tx) error) error {
+	m.txCallCount++
+	if len(m.txErrs) > 0 {
+		err := m.txErrs[0]
+		m.txErrs = m.txErrs[1:]
+		return err
+	}
+	return m.txErr
+}
+
+func (m *mockDatabase) Exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	m.execCallCount++
+	if len(m.execErrs) > 0 {
+		err := m.execErrs[0]
+		m.execErrs = m.execErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	if m.execErr != nil {
+		return nil, m.execErr
+	}
+	return m.execResult, nil
+}
+
+func (m *mockDatabase) Query(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	m.queryCallCount++
+	if len(m.queryErrs) > 0 {
+		err := m.queryErrs[0]
+		m.queryErrs = m.queryErrs[1:]
+		return nil, err
+	}
+	return nil, m.queryErr
+}
+
+func (m *mockDatabase) QueryRow(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return nil
+}

--- a/internal/email/metrics_test.go
+++ b/internal/email/metrics_test.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -176,5 +177,86 @@ func TestMockMetrics(t *testing.T) {
 		if len(metrics.batchSizes) != 1 || metrics.batchSizes[0] != 10 {
 			t.Errorf("Expected batch size 10, got %v", metrics.batchSizes)
 		}
+	})
+}
+
+// assertNoPanic runs fn and fails the test (with the given label) if fn panics.
+// The noOpMetrics methods are empty no-ops; their contract is "safe to call,
+// never panic, no side effects". This helper turns that contract into an
+// explicit assertion.
+func assertNoPanic(t *testing.T, label string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s panicked: %v", label, r)
+		}
+	}()
+	fn()
+}
+
+// TestMetricsNoOp exercises every noOpMetrics method across happy, edge and
+// unhappy inputs (table-driven). Each call must be a safe no-op.
+func TestMetricsNoOp(t *testing.T) {
+	metrics := NewNoOpMetrics()
+	if metrics == nil {
+		t.Fatal("NewNoOpMetrics() returned nil")
+	}
+
+	tests := []struct {
+		name string
+		fn   func()
+	}{
+		// Happy paths
+		{"RecordQueueSize positive", func() { metrics.RecordQueueSize(100) }},
+		{"RecordEmailQueued", func() { metrics.RecordEmailQueued() }},
+		{"RecordEmailDequeued", func() { metrics.RecordEmailDequeued() }},
+		{"RecordEmailSent", func() { metrics.RecordEmailSent(2 * time.Second) }},
+		{"RecordEmailFailed", func() { metrics.RecordEmailFailed("smtp_error") }},
+		{"RecordRetryAttempt", func() { metrics.RecordRetryAttempt(3) }},
+		{"RecordRateLimitHit", func() { metrics.RecordRateLimitHit() }},
+		{"RecordRateLimitWait", func() { metrics.RecordRateLimitWait(5 * time.Second) }},
+		{"RecordBatchProcessed", func() { metrics.RecordBatchProcessed(10, 3*time.Second) }},
+		{"RecordProcessingError non-nil", func() { metrics.RecordProcessingError(errors.New("boom")) }},
+
+		// Edge / unhappy paths
+		{"RecordQueueSize zero", func() { metrics.RecordQueueSize(0) }},
+		{"RecordQueueSize negative", func() { metrics.RecordQueueSize(-5) }},
+		{"RecordEmailSent zero duration", func() { metrics.RecordEmailSent(0) }},
+		{"RecordEmailFailed empty reason", func() { metrics.RecordEmailFailed("") }},
+		{"RecordRetryAttempt zero", func() { metrics.RecordRetryAttempt(0) }},
+		{"RecordRateLimitWait zero", func() { metrics.RecordRateLimitWait(0) }},
+		{"RecordBatchProcessed zero", func() { metrics.RecordBatchProcessed(0, 0) }},
+		{"RecordProcessingError nil", func() { metrics.RecordProcessingError(nil) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertNoPanic(t, tt.name, tt.fn)
+		})
+	}
+}
+
+// TestMetricsNoOpImplementsInterface guarantees the no-op satisfies the
+// Metrics interface at compile time and that repeated calls are idempotent.
+func TestMetricsNoOpImplementsInterface(t *testing.T) {
+	var _ Metrics = NewNoOpMetrics()
+
+	metrics := NewNoOpMetrics()
+
+	// Repeated calls must remain safe (idempotent no-op).
+	for i := 0; i < 5; i++ {
+		metrics.RecordEmailQueued()
+		metrics.RecordEmailDequeued()
+		metrics.RecordEmailSent(time.Second)
+		metrics.RecordRetryAttempt(i)
+		metrics.RecordBatchProcessed(i, time.Second)
+	}
+
+	assertNoPanic(t, "repeated mixed calls", func() {
+		metrics.RecordQueueSize(0)
+		metrics.RecordEmailFailed("anything")
+		metrics.RecordRateLimitHit()
+		metrics.RecordRateLimitWait(0)
+		metrics.RecordProcessingError(nil)
 	})
 }

--- a/internal/email/smtp_sender_test.go
+++ b/internal/email/smtp_sender_test.go
@@ -1,8 +1,13 @@
 package email
 
 import (
+	"bufio"
+	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -415,5 +420,287 @@ func TestSMTPSender_Close_MultipleCalls(t *testing.T) {
 	err = sender.Close()
 	if err != nil {
 		t.Errorf("Second Close() error = %v, want nil", err)
+	}
+}
+
+// fakeSMTPServer is a minimal in-process SMTP server used to exercise
+// (*smtpSender).Send without an external (MailHog) dependency. It speaks just
+// enough of the SMTP protocol for the net/smtp client to authenticate, send a
+// message and quit. Per-command response overrides let tests simulate
+// permanent/transient failures at any step.
+type fakeSMTPServer struct {
+	listener net.Listener
+	host     string
+	port     int
+
+	// Optional response overrides. When empty, a default success response is sent.
+	authResp   string // response to AUTH (default "235 OK")
+	mailResp   string // response to MAIL FROM (default "250 OK")
+	rcptResp   string // response to RCPT TO (default "250 OK")
+	dataResp   string // response to the final "." of DATA (default "250 OK")
+	dataCmdResp string // response to the DATA command (default "354 ..."); when set, DATA is rejected and data mode is not entered
+	quitResp   string // response to QUIT (default "221 Bye")
+
+	dropOnConnect bool // close the connection immediately (simulates reset)
+}
+
+func newFakeSMTPServer(t *testing.T) *fakeSMTPServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start fake SMTP server: %v", err)
+	}
+	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	s := &fakeSMTPServer{listener: ln, host: host, port: port}
+	go s.serve()
+	return s
+}
+
+func (s *fakeSMTPServer) close() {
+	s.listener.Close()
+}
+
+func (s *fakeSMTPServer) serve() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *fakeSMTPServer) handle(conn net.Conn) {
+	defer conn.Close()
+	if s.dropOnConnect {
+		return
+	}
+	r := bufio.NewReader(conn)
+	writeLine := func(msg string) {
+		conn.Write([]byte(msg))
+	}
+	orDefault := func(resp, def string) string {
+		if resp != "" {
+			return resp
+		}
+		return def
+	}
+
+	writeLine("220 fake.smtp ESMTP ready\r\n")
+
+	inData := false
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		if inData {
+			if strings.TrimSpace(line) == "." {
+				inData = false
+				writeLine(orDefault(s.dataResp, "250 OK\r\n"))
+			}
+			continue
+		}
+		upper := strings.ToUpper(strings.TrimSpace(line))
+		switch {
+		case strings.HasPrefix(upper, "EHLO"), strings.HasPrefix(upper, "HELO"):
+			writeLine("250 fake.smtp\r\n")
+		case strings.HasPrefix(upper, "AUTH"):
+			writeLine(orDefault(s.authResp, "235 OK\r\n"))
+		case strings.HasPrefix(upper, "MAIL"):
+			writeLine(orDefault(s.mailResp, "250 OK\r\n"))
+		case strings.HasPrefix(upper, "RCPT"):
+			writeLine(orDefault(s.rcptResp, "250 OK\r\n"))
+		case strings.HasPrefix(upper, "DATA"):
+			if s.dataCmdResp != "" {
+				writeLine(s.dataCmdResp)
+			} else {
+				writeLine("354 Start mail input; end with <CRLF>.<CRLF>\r\n")
+				inData = true
+			}
+		case strings.HasPrefix(upper, "QUIT"):
+			writeLine(orDefault(s.quitResp, "221 Bye\r\n"))
+			return
+		case strings.HasPrefix(upper, "RSET"), strings.HasPrefix(upper, "NOOP"):
+			writeLine("250 OK\r\n")
+		default:
+			writeLine("500 Unrecognized command\r\n")
+		}
+	}
+}
+
+// TestSMTPSender_Send exercises (*smtpSender).Send against an in-process fake
+// SMTP server, covering happy paths (with and without auth) and unhappy paths
+// where the server rejects a command with a permanent (5xx) SMTP error.
+func TestSMTPSender_Send(t *testing.T) {
+	tests := []struct {
+		name     string
+		useAuth  bool
+		setup    func(*fakeSMTPServer)
+		wantErr  bool
+		wantPerm bool // expect the error to be a *PermanentError
+	}{
+		{
+			name:    "happy path without auth",
+			useAuth: false,
+			wantErr: false,
+		},
+		{
+			name:    "happy path with auth",
+			useAuth: true,
+			wantErr: false,
+		},
+		{
+			name:     "rcpt rejected yields permanent error",
+			setup:    func(s *fakeSMTPServer) { s.rcptResp = "550 No such user\r\n" },
+			wantErr:  true,
+			wantPerm: true,
+		},
+		{
+			name:     "mail from rejected yields permanent error",
+			setup:    func(s *fakeSMTPServer) { s.mailResp = "550 Sender not allowed\r\n" },
+			wantErr:  true,
+			wantPerm: true,
+		},
+		{
+			name:     "data rejected yields permanent error",
+			setup:    func(s *fakeSMTPServer) { s.dataResp = "554 Message rejected\r\n" },
+			wantErr:  true,
+			wantPerm: true,
+		},
+		{
+			name:     "data command rejected yields permanent error",
+			setup:    func(s *fakeSMTPServer) { s.dataCmdResp = "554 No data accepted\r\n" },
+			wantErr:  true,
+			wantPerm: true,
+		},
+		{
+			name:    "auth rejected yields non-classified error",
+			useAuth: true,
+			setup:   func(s *fakeSMTPServer) { s.authResp = "535 Authentication failed\r\n" },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newFakeSMTPServer(t)
+			defer srv.close()
+			if tt.setup != nil {
+				tt.setup(srv)
+			}
+
+			cfg := testConfig()
+			cfg.SMTPHost = srv.host
+			cfg.SMTPPort = srv.port
+			cfg.UseTLS = false
+			cfg.SkipVerify = false
+			cfg.Timeout = 5 * time.Second
+			if !tt.useAuth {
+				cfg.SMTPUsername = ""
+				cfg.SMTPPassword = ""
+			}
+
+			sender, err := NewSMTPSender(cfg)
+			if err != nil {
+				t.Fatalf("NewSMTPSender() error = %v", err)
+			}
+
+			toName := "Recipient"
+			msg := &SMTPMessage{
+				To:       "recipient@example.com",
+				ToName:   &toName,
+				Subject:  "Test Subject",
+				BodyText: "plain body",
+				BodyHTML: "<p>html body</p>",
+			}
+
+			err = sender.Send(context.Background(), msg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Send() error = nil, want error")
+				}
+				if tt.wantPerm {
+					if _, ok := err.(*PermanentError); !ok {
+						t.Errorf("Send() error = %T (%v), want *PermanentError", err, err)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Send() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestSMTPSender_Send_DialFailure covers the unhappy path where the SMTP server
+// is unreachable: Send must surface a "failed to connect to SMTP" error.
+func TestSMTPSender_Send_DialFailure(t *testing.T) {
+	cfg := testConfig()
+	cfg.SMTPHost = "127.0.0.1"
+	cfg.SMTPPort = 1 // nothing listening on port 1 -> connection refused
+	cfg.UseTLS = false
+	cfg.Timeout = 2 * time.Second
+
+	sender, err := NewSMTPSender(cfg)
+	if err != nil {
+		t.Fatalf("NewSMTPSender() error = %v", err)
+	}
+
+	msg := &SMTPMessage{
+		To:       "recipient@example.com",
+		Subject:  "Test",
+		BodyText: "body",
+	}
+
+	err = sender.Send(context.Background(), msg)
+	if err == nil {
+		t.Fatal("Send() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "failed to connect to SMTP") {
+		t.Errorf("Send() error = %q, want it to contain %q", err.Error(), "failed to connect to SMTP")
+	}
+}
+
+// TestSMTPSender_PermanentError_Unwrap covers PermanentError.Unwrap (and the
+// errors.Is integration that relies on it) across a wrapped error and nil.
+func TestSMTPSender_PermanentError_Unwrap(t *testing.T) {
+	tests := []struct {
+		name    string
+		wrapped error
+		wantNil bool
+	}{
+		{"wrapped error", errors.New("550 mailbox unavailable"), false},
+		{"nil wrapped", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pe := &PermanentError{Err: tt.wrapped}
+
+			got := pe.Unwrap()
+			if got != tt.wrapped {
+				t.Errorf("Unwrap() = %v, want %v", got, tt.wrapped)
+			}
+			if tt.wantNil && got != nil {
+				t.Errorf("Unwrap() = %v, want nil", got)
+			}
+
+			// errors.Is exercises Unwrap on the non-nil path.
+			if tt.wrapped != nil {
+				if !errors.Is(pe, tt.wrapped) {
+					t.Errorf("errors.Is(pe, wrapped) = false, want true")
+				}
+			}
+
+			// Error() should embed the wrapped message when non-nil.
+			if tt.wrapped != nil {
+				if !strings.Contains(pe.Error(), tt.wrapped.Error()) {
+					t.Errorf("Error() = %q, want it to contain %q", pe.Error(), tt.wrapped.Error())
+				}
+			}
+		})
 	}
 }

--- a/internal/email/stubs_test.go
+++ b/internal/email/stubs_test.go
@@ -3,6 +3,7 @@ package email
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestStubSMTPSender_Send(t *testing.T) {
@@ -92,5 +93,82 @@ func TestStubRateLimiter_AvailableSlotsAfterAllow(t *testing.T) {
 	slots := limiter.AvailableSlots()
 	if slots != 1000 {
 		t.Errorf("AvailableSlots() = %d, want 1000", slots)
+	}
+}
+
+// TestStubRateLimiter_WaitTime covers stubRateLimiter.WaitTime, which must
+// always report zero wait regardless of prior calls (table-driven).
+func TestStubRateLimiter_WaitTime(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(RateLimiter)
+		want  time.Duration
+	}{
+		{"fresh limiter", nil, 0},
+		{"after allow", func(r RateLimiter) { r.Allow() }, 0},
+		{"after record", func(r RateLimiter) { r.Record() }, 0},
+		{"after many records", func(r RateLimiter) {
+			for i := 0; i < 100; i++ {
+				r.Record()
+			}
+		}, 0},
+		{"after reset", func(r RateLimiter) { r.Reset() }, 0},
+		{"after allow, record and reset", func(r RateLimiter) {
+			r.Allow()
+			r.Record()
+			r.Reset()
+		}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limiter := NewStubRateLimiter()
+			if tt.setup != nil {
+				tt.setup(limiter)
+			}
+			if got := limiter.WaitTime(); got != tt.want {
+				t.Errorf("WaitTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStubRateLimiter_Record covers stubRateLimiter.Record: it is a stateless
+// no-op, so many calls must not panic or alter Allow/AvailableSlots/WaitTime.
+func TestStubRateLimiter_Record(t *testing.T) {
+	limiter := NewStubRateLimiter()
+
+	for i := 0; i < 50; i++ {
+		limiter.Record()
+	}
+
+	if !limiter.Allow() {
+		t.Error("Allow() = false, want true after Record calls")
+	}
+	if got := limiter.AvailableSlots(); got != 1000 {
+		t.Errorf("AvailableSlots() = %d, want 1000 after Record calls", got)
+	}
+	if got := limiter.WaitTime(); got != 0 {
+		t.Errorf("WaitTime() = %v, want 0 after Record calls", got)
+	}
+}
+
+// TestStubRateLimiter_Reset covers stubRateLimiter.Reset: it is a stateless
+// no-op, so behaviour must be unchanged after a reset.
+func TestStubRateLimiter_Reset(t *testing.T) {
+	limiter := NewStubRateLimiter()
+
+	limiter.Allow()
+	limiter.Record()
+	limiter.Reset()
+
+	if !limiter.Allow() {
+		t.Error("Allow() = false, want true after Reset")
+	}
+	if got := limiter.AvailableSlots(); got != 1000 {
+		t.Errorf("AvailableSlots() = %d, want 1000 after Reset", got)
+	}
+	if got := limiter.WaitTime(); got != 0 {
+		t.Errorf("WaitTime() = %v, want 0 after Reset", got)
 	}
 }

--- a/internal/events/service_test.go
+++ b/internal/events/service_test.go
@@ -27,6 +27,7 @@ type mockEventRepository struct {
 	GetComponentOverridesFunc    func(ctx context.Context, eventID int64) (*models.ComponentOverrides, error)
 	UpdateComponentOverridesFunc func(ctx context.Context, eventID int64, overrides *models.ComponentOverrides) error
 	DeleteComponentOverridesFunc func(ctx context.Context, eventID int64) error
+	ListWithStatsFunc              func(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error)
 }
 
 func (m *mockEventRepository) Create(ctx context.Context, event *models.Event) error {
@@ -93,6 +94,9 @@ func (m *mockEventRepository) List(ctx context.Context, filters repositories.Lis
 }
 
 func (m *mockEventRepository) ListWithStats(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error) {
+	if m.ListWithStatsFunc != nil {
+		return m.ListWithStatsFunc(ctx, filters)
+	}
 	return nil, nil
 }
 
@@ -1477,4 +1481,41 @@ func TestService_GetEventsToArchive(t *testing.T) {
 
 func (m * mockEventRepository) GetDashboardStatsByCreator(ctx context.Context, creatorID int64) (*models.DashboardStats, error) {
 	return &models.DashboardStats{}, nil
+}
+
+func TestListEventsWithStats_Unauthorized(t *testing.T) {
+	repo := &mockEventRepository{}
+	authz := auth.NewAuthorizationChecker()
+	svc := NewService(repo, nil, NewValidator(NewTimezoneValidator()), authz)
+
+	_, err := svc.ListEventsWithStats(context.Background(), repositories.ListFilters{})
+	if err == nil {
+		t.Fatal("expected error without user in context")
+	}
+}
+
+func TestListEventsWithStats_AsEventManager(t *testing.T) {
+	repo := &mockEventRepository{
+		ListWithStatsFunc: func(ctx context.Context, filters repositories.ListFilters) ([]*models.EventWithStats, error) {
+			return []*models.EventWithStats{
+				{Event: models.Event{ID: 1, Title: "Test"}, InviteCount: 5, RSVPCount: 3, AcceptCount: 2},
+			}, nil
+		},
+	}
+	authz := auth.NewAuthorizationChecker()
+	svc := NewService(repo, nil, NewValidator(NewTimezoneValidator()), authz)
+
+	user := &models.User{ID: 1, Role: models.RoleEventManager}
+	ctx := auth.WithUser(context.Background(), user)
+
+	results, err := svc.ListEventsWithStats(ctx, repositories.ListFilters{})
+	if err != nil {
+		t.Fatalf("ListEventsWithStats: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].InviteCount != 5 {
+		t.Errorf("InviteCount = %d, want 5", results[0].InviteCount)
+	}
 }

--- a/internal/handlers/coverage_test.go
+++ b/internal/handlers/coverage_test.go
@@ -1,0 +1,562 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/lenaxia/tinyrsvp/internal/auth"
+	"github.com/lenaxia/tinyrsvp/internal/config"
+	"github.com/lenaxia/tinyrsvp/internal/db"
+	"github.com/lenaxia/tinyrsvp/internal/email"
+	"github.com/lenaxia/tinyrsvp/internal/models"
+)
+
+// TestCoverageConstructors verifies that every handler constructor returns a
+// non-nil instance. These constructors simply store their dependencies, so nil
+// dependencies are acceptable for the non-nil assertion.
+func TestCoverageConstructors(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func() interface{}
+	}{
+		{"AdminDashboard", func() interface{} { return NewAdminDashboardHandler(nil) }},
+		{"UserManagement", func() interface{} { return NewUserManagementHandler(nil) }},
+		{"EventCustomization", func() interface{} { return NewEventCustomizationHandlers(nil) }},
+		{"Invite", func() interface{} { return NewInviteHandlers(nil, "") }},
+		{"ImportInvite", func() interface{} { return NewImportInviteHandlers(nil, nil, "") }},
+		{"DeleteInvite", func() interface{} { return NewDeleteInviteHandlers(nil, nil) }},
+		{"GetInvite", func() interface{} { return NewGetInviteHandlers(nil, nil) }},
+		{"ManualInvite", func() interface{} { return NewManualInviteHandlers(nil, nil, "") }},
+		{"RegenerateInviteToken", func() interface{} { return NewRegenerateInviteTokenHandlers(nil, nil) }},
+		{"RevokeInvite", func() interface{} { return NewRevokeInviteHandlers(nil, nil) }},
+		{"SendInvite", func() interface{} { return NewSendInviteHandlers(nil, nil, nil, "") }},
+		{"UpdateInvite", func() interface{} { return NewUpdateInviteHandlers(nil, nil) }},
+		{"Metrics", func() interface{} { return NewMetricsHandler(nil) }},
+		{"Question", func() interface{} { return NewQuestionHandlers(nil) }},
+		{"Settings", func() interface{} { return NewSettingsHandler(&config.Config{}) }},
+		{"TemplateEditor", func() interface{} { return NewTemplateEditorHandlers(nil) }},
+		{"Template", func() interface{} { return NewTemplateHandlers(nil) }},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.fn(); got == nil {
+				t.Errorf("%s constructor returned nil", c.name)
+			}
+		})
+	}
+}
+
+// TestCoverageSetTemplates verifies each SetTemplates method stores the template
+// pointer on the handler. The test lives in the same package so it can read the
+// unexported templates field directly.
+func TestCoverageSetTemplates(t *testing.T) {
+	tmpl := template.Must(template.New("t").Parse("hello"))
+
+	adminH := NewAdminDashboardHandler(nil)
+	adminH.SetTemplates(tmpl)
+	if adminH.templates == nil {
+		t.Error("AdminDashboardHandler.templates not set")
+	}
+
+	userH := NewUserManagementHandler(nil)
+	userH.SetTemplates(tmpl)
+	if userH.templates == nil {
+		t.Error("UserManagementHandler.templates not set")
+	}
+
+	custH := NewEventCustomizationHandlers(nil)
+	custH.SetTemplates(tmpl)
+	if custH.templates == nil {
+		t.Error("EventCustomizationHandlers.templates not set")
+	}
+
+	metricsH := NewMetricsHandler(nil)
+	metricsH.SetTemplates(tmpl)
+	if metricsH.templates == nil {
+		t.Error("MetricsHandler.templates not set")
+	}
+
+	settingsH := NewSettingsHandler(&config.Config{})
+	settingsH.SetTemplates(tmpl)
+	if settingsH.templates == nil {
+		t.Error("SettingsHandler.templates not set")
+	}
+
+	editorH := NewTemplateEditorHandlers(nil)
+	editorH.SetTemplates(tmpl)
+	if editorH.templates == nil {
+		t.Error("TemplateEditorHandlers.templates not set")
+	}
+}
+
+// TestCoverageRegisterRoutes verifies each RegisterRoutes method registers its
+// routes on a chi router without panicking. The handlers' dependencies are not
+// consulted during route registration, so nil dependencies are acceptable.
+func TestCoverageRegisterRoutes(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func(r chi.Router)
+	}{
+		{"EventCustomization", func(r chi.Router) { NewEventCustomizationHandlers(nil).RegisterRoutes(r) }},
+		{"Invite", func(r chi.Router) { NewInviteHandlers(nil, "").RegisterRoutes(r) }},
+		{"ImportInvite", func(r chi.Router) { NewImportInviteHandlers(nil, nil, "").RegisterRoutes(r) }},
+		{"DeleteInvite", func(r chi.Router) { NewDeleteInviteHandlers(nil, nil).RegisterRoutes(r) }},
+		{"GetInvite", func(r chi.Router) { NewGetInviteHandlers(nil, nil).RegisterRoutes(r) }},
+		{"ManualInvite", func(r chi.Router) { NewManualInviteHandlers(nil, nil, "").RegisterRoutes(r) }},
+		{"RegenerateInviteToken", func(r chi.Router) { NewRegenerateInviteTokenHandlers(nil, nil).RegisterRoutes(r) }},
+		{"RevokeInvite", func(r chi.Router) { NewRevokeInviteHandlers(nil, nil).RegisterRoutes(r) }},
+		{"SendInvite", func(r chi.Router) { NewSendInviteHandlers(nil, nil, nil, "").RegisterRoutes(r) }},
+		{"UpdateInvite", func(r chi.Router) { NewUpdateInviteHandlers(nil, nil).RegisterRoutes(r) }},
+		{"Question", func(r chi.Router) { NewQuestionHandlers(nil).RegisterRoutes(r) }},
+		{"TemplateEditor", func(r chi.Router) { NewTemplateEditorHandlers(nil).RegisterRoutes(r) }},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("RegisterRoutes panicked: %v", r)
+				}
+			}()
+			c.fn(chi.NewRouter())
+		})
+	}
+}
+
+// --- metrics_adapter.go adapter tests ---
+
+// mockEmailHealthChecker implements EmailHealthChecker for adapter tests.
+type mockEmailHealthChecker struct {
+	getStatusFunc func(ctx context.Context) (*email.HealthStatus, error)
+}
+
+func (m *mockEmailHealthChecker) GetStatus(ctx context.Context) (*email.HealthStatus, error) {
+	if m.getStatusFunc != nil {
+		return m.getStatusFunc(ctx)
+	}
+	return &email.HealthStatus{Healthy: true}, nil
+}
+
+// mockMetricsDatabase implements db.Database for adapter tests. Only DB() is
+// exercised by GetDBStats; the remaining methods return zero values.
+type mockMetricsDatabase struct {
+	db *sql.DB
+}
+
+func (m *mockMetricsDatabase) DB() *sql.DB { return m.db }
+func (m *mockMetricsDatabase) Close() error { return nil }
+func (m *mockMetricsDatabase) Ping(ctx context.Context) error { return nil }
+func (m *mockMetricsDatabase) WithTransaction(ctx context.Context, fn func(*sql.Tx) error) error {
+	return nil
+}
+func (m *mockMetricsDatabase) Exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return nil, nil
+}
+func (m *mockMetricsDatabase) Query(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return nil, nil
+}
+func (m *mockMetricsDatabase) QueryRow(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return nil
+}
+
+// mockAdminStatsSource implements AdminDashboardService for adapter tests.
+type mockAdminStatsSource struct {
+	getAdminStatsFunc func(ctx context.Context) (*AdminDashboardStats, error)
+}
+
+func (m *mockAdminStatsSource) GetAdminStats(ctx context.Context) (*AdminDashboardStats, error) {
+	if m.getAdminStatsFunc != nil {
+		return m.getAdminStatsFunc(ctx)
+	}
+	return &AdminDashboardStats{TotalUsers: 1, TotalEvents: 2, TotalInvites: 3}, nil
+}
+
+func TestCoverageMetricsDataSource_New(t *testing.T) {
+	src := NewMetricsDataSource(&mockAdminStatsSource{}, &mockEmailHealthChecker{}, &mockMetricsDatabase{})
+	if src == nil {
+		t.Fatal("NewMetricsDataSource returned nil")
+	}
+}
+
+func TestCoverageMetricsDataSource_GetAdminStats_Delegates(t *testing.T) {
+	want := &AdminDashboardStats{TotalUsers: 7, TotalEvents: 3, TotalInvites: 12}
+	adminSvc := &mockAdminStatsSource{
+		getAdminStatsFunc: func(ctx context.Context) (*AdminDashboardStats, error) {
+			return want, nil
+		},
+	}
+	src := NewMetricsDataSource(adminSvc, &mockEmailHealthChecker{}, &mockMetricsDatabase{})
+
+	got, err := src.GetAdminStats(context.Background())
+	if err != nil {
+		t.Fatalf("GetAdminStats returned error: %v", err)
+	}
+	if got.TotalUsers != 7 || got.TotalEvents != 3 || got.TotalInvites != 12 {
+		t.Errorf("GetAdminStats mapped fields = %+v, want %+v", got, want)
+	}
+}
+
+func TestCoverageMetricsDataSource_GetAdminStats_Error(t *testing.T) {
+	wantErr := errors.New("admin stats unavailable")
+	adminSvc := &mockAdminStatsSource{
+		getAdminStatsFunc: func(ctx context.Context) (*AdminDashboardStats, error) {
+			return nil, wantErr
+		},
+	}
+	src := NewMetricsDataSource(adminSvc, &mockEmailHealthChecker{}, &mockMetricsDatabase{})
+
+	got, err := src.GetAdminStats(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Errorf("GetAdminStats error = %v, want %v", err, wantErr)
+	}
+	if got != nil {
+		t.Errorf("GetAdminStats result = %v, want nil on error", got)
+	}
+}
+
+func TestCoverageMetricsDataSource_GetEmailQueueStatus_Delegates(t *testing.T) {
+	emailChk := &mockEmailHealthChecker{
+		getStatusFunc: func(ctx context.Context) (*email.HealthStatus, error) {
+			return &email.HealthStatus{
+				Healthy:      true,
+				QueueSize:    4,
+				SendingCount: 2,
+				FailedCount:  1,
+			}, nil
+		},
+	}
+	src := NewMetricsDataSource(&mockAdminStatsSource{}, emailChk, &mockMetricsDatabase{})
+
+	got, err := src.GetEmailQueueStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetEmailQueueStatus returned error: %v", err)
+	}
+	if got.QueueSize != 4 || got.SendingCount != 2 || got.FailedCount != 1 || !got.Healthy {
+		t.Errorf("GetEmailQueueStatus mapped fields = %+v", got)
+	}
+}
+
+func TestCoverageMetricsDataSource_GetEmailQueueStatus_Error(t *testing.T) {
+	wantErr := errors.New("email checker unavailable")
+	emailChk := &mockEmailHealthChecker{
+		getStatusFunc: func(ctx context.Context) (*email.HealthStatus, error) {
+			return nil, wantErr
+		},
+	}
+	src := NewMetricsDataSource(&mockAdminStatsSource{}, emailChk, &mockMetricsDatabase{})
+
+	got, err := src.GetEmailQueueStatus(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Errorf("GetEmailQueueStatus error = %v, want %v", err, wantErr)
+	}
+	if got != nil {
+		t.Errorf("GetEmailQueueStatus result = %v, want nil on error", got)
+	}
+}
+
+func TestCoverageMetricsDataSource_GetDBStats_Delegates(t *testing.T) {
+	sqlDB, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Skipf("sqlite3 not available: %v", err)
+	}
+	defer sqlDB.Close()
+	sqlDB.SetMaxOpenConns(3)
+
+	database := &mockMetricsDatabase{db: sqlDB}
+	src := NewMetricsDataSource(&mockAdminStatsSource{}, &mockEmailHealthChecker{}, database)
+
+	got, err := src.GetDBStats()
+	if err != nil {
+		t.Fatalf("GetDBStats returned error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetDBStats returned nil metrics")
+	}
+	if got.MaxOpenConnections != 3 {
+		t.Errorf("MaxOpenConnections = %d, want 3", got.MaxOpenConnections)
+	}
+}
+
+// --- settings.go tests ---
+
+func TestCoverageSettings_NewHandler(t *testing.T) {
+	h := NewSettingsHandler(&config.Config{})
+	if h == nil {
+		t.Fatal("NewSettingsHandler returned nil")
+	}
+}
+
+func TestCoverageSettings_SetTemplates(t *testing.T) {
+	tmpl := template.Must(template.New("t").Parse("settings"))
+	h := NewSettingsHandler(&config.Config{})
+	h.SetTemplates(tmpl)
+	if h.templates == nil {
+		t.Error("SettingsHandler.templates not set")
+	}
+}
+
+func TestCoverageSettings_Page_WithoutTemplates(t *testing.T) {
+	h := NewSettingsHandler(&config.Config{})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+	user := &models.User{ID: 1, Email: "admin@example.com", Name: "Admin", Role: models.RoleAdmin}
+	req = req.WithContext(auth.WithUser(req.Context(), user))
+
+	w := httptest.NewRecorder()
+	h.SettingsPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (fallback render)", w.Code, http.StatusOK)
+	}
+}
+
+func TestCoverageSettings_Page_WithTemplates(t *testing.T) {
+	tmpl := template.Must(template.New("admin_settings.html").Parse(`<p>{{.ActivePage}}</p>`))
+	h := NewSettingsHandler(&config.Config{})
+	h.SetTemplates(tmpl)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+	user := &models.User{ID: 1, Email: "admin@example.com", Name: "Admin", Role: models.RoleAdmin}
+	req = req.WithContext(auth.WithUser(req.Context(), user))
+
+	w := httptest.NewRecorder()
+	h.SettingsPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestCoverageSettings_Page_Unauthorized(t *testing.T) {
+	h := NewSettingsHandler(&config.Config{})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+	req.Header.Set("Accept", "application/json")
+
+	w := httptest.NewRecorder()
+	h.SettingsPage(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+// --- events_id_resolver.go: resolveEventIDFromRepo ---
+
+// covEventRepo embeds mockRSVPEventRepository so it still satisfies
+// repositories.EventRepository, while overriding the fallthrough lookups that
+// the base mock hardcodes to (nil, nil).
+type covEventRepo struct {
+	*mockRSVPEventRepository
+	getByPublicIDFunc     func(ctx context.Context, publicID string) (*models.Event, error)
+	getByFriendlyNameFunc func(ctx context.Context, friendlyName string) (*models.Event, error)
+}
+
+func (m *covEventRepo) GetByPublicID(ctx context.Context, publicID string) (*models.Event, error) {
+	if m.getByPublicIDFunc != nil {
+		return m.getByPublicIDFunc(ctx, publicID)
+	}
+	return nil, &models.NotFoundError{Resource: "Event", ID: publicID}
+}
+
+func (m *covEventRepo) GetByFriendlyName(ctx context.Context, friendlyName string) (*models.Event, error) {
+	if m.getByFriendlyNameFunc != nil {
+		return m.getByFriendlyNameFunc(ctx, friendlyName)
+	}
+	return nil, &models.NotFoundError{Resource: "Event", ID: friendlyName}
+}
+
+func TestCoverageResolveEventIDFromRepo(t *testing.T) {
+	repo := &covEventRepo{
+		mockRSVPEventRepository: &mockRSVPEventRepository{
+			getByIDFunc: func(ctx context.Context, id int64) (*models.Event, error) {
+				if id == 123 {
+					return &models.Event{ID: 123, Title: "Found by ID"}, nil
+				}
+				return nil, &models.NotFoundError{Resource: "Event", ID: id}
+			},
+		},
+	}
+
+	t.Run("found by numeric id", func(t *testing.T) {
+		event, err := resolveEventIDFromRepo(context.Background(), repo, "123")
+		if err != nil {
+			t.Fatalf("resolveEventIDFromRepo error = %v", err)
+		}
+		if event == nil || event.ID != 123 {
+			t.Errorf("resolveEventIDFromRepo event = %+v, want ID 123", event)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		event, err := resolveEventIDFromRepo(context.Background(), repo, "nonexistent-event")
+		if err == nil {
+			t.Error("resolveEventIDFromRepo expected error, got nil")
+		}
+		if event != nil {
+			t.Errorf("resolveEventIDFromRepo event = %+v, want nil", event)
+		}
+	})
+}
+
+// --- rsvp.go: GetCalendar ---
+
+func TestCoverageGetCalendar(t *testing.T) {
+	inviteSvc := &mockRSVPInviteService{
+		getInviteByTokenFunc: func(ctx context.Context, token string) (*models.Invite, error) {
+			return &models.Invite{ID: 1, EventID: 10}, nil
+		},
+	}
+	eventRepo := &mockRSVPEventRepository{
+		getByIDFunc: func(ctx context.Context, id int64) (*models.Event, error) {
+			return &models.Event{
+				ID:        10,
+				Title:     "Test Event",
+				StartTime: time.Now().Add(24 * time.Hour),
+				Timezone:  "UTC",
+			}, nil
+		},
+	}
+	h := NewRSVPHandler(inviteSvc, eventRepo, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/rsvp/abc123/calendar", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("token", "abc123")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	h.GetCalendar(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/calendar; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want text/calendar", ct)
+	}
+}
+
+func TestCoverageGetCalendar_NoToken(t *testing.T) {
+	h := NewRSVPHandler(&mockRSVPInviteService{}, &mockRSVPEventRepository{}, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/rsvp//calendar", nil)
+	rctx := chi.NewRouteContext()
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	h.GetCalendar(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+// --- template_editor.go: parseTemplateIDFromPath ---
+
+func TestCoverageParseTemplateIDFromPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantID  int64
+		wantErr bool
+	}{
+		{"valid", "42", 42, false},
+		{"non-numeric", "abc", 0, true},
+		{"zero", "0", 0, true},
+		{"negative", "-5", 0, true},
+		{"empty", "", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			id, err := parseTemplateIDFromPath(c.input)
+			if (err != nil) != c.wantErr {
+				t.Errorf("parseTemplateIDFromPath(%q) error = %v, wantErr %v", c.input, err, c.wantErr)
+			}
+			if id != c.wantID {
+				t.Errorf("parseTemplateIDFromPath(%q) id = %d, want %d", c.input, id, c.wantID)
+			}
+		})
+	}
+}
+
+// --- templates.go: SetDefault ---
+
+func TestCoverageTemplateHandlers_SetDefault(t *testing.T) {
+	var calledID int64
+	svc := &mockTemplateService{
+		SetDefaultFunc: func(ctx context.Context, id int64) error {
+			calledID = id
+			return nil
+		},
+	}
+	h := NewTemplateHandlers(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/templates/5/set-default", nil)
+	req = req.WithContext(auth.WithUser(context.Background(), &models.User{
+		ID: 1, Email: "mgr@example.com", Name: "Manager", Role: models.RoleEventManager,
+	}))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "5")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	h.SetDefault(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if calledID != 5 {
+		t.Errorf("service.SetDefault called with id %d, want 5", calledID)
+	}
+}
+
+// --- event_customization.go: CustomizationPage ---
+
+func TestCoverageCustomizationPage_WithTemplates(t *testing.T) {
+	tmpl := template.Must(template.New("event_customization.html").Parse(`event:{{.EventID}}`))
+	h := NewEventCustomizationHandlers(nil)
+	h.SetTemplates(tmpl)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/42/template/customization", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "42")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	h.CustomizationPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestCoverageCustomizationPage_NoTemplates(t *testing.T) {
+	h := NewEventCustomizationHandlers(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/42/template/customization", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "42")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	h.CustomizationPage(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+// Compile-time assertions that the adapter mocks satisfy their interfaces.
+var (
+	_ EmailHealthChecker = (*mockEmailHealthChecker)(nil)
+	_ db.Database        = (*mockMetricsDatabase)(nil)
+	_ AdminDashboardService = (*mockAdminStatsSource)(nil)
+)

--- a/internal/invites/service_test.go
+++ b/internal/invites/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lenaxia/tinyrsvp/internal/db/repositories"
 	"github.com/lenaxia/tinyrsvp/internal/models"
+	"github.com/lenaxia/tinyrsvp/pkg/token"
 )
 
 type mockGenerator struct {
@@ -959,5 +960,59 @@ func TestInviteService_CleanupExpiredTokens(t *testing.T) {
 				tt.validateResult(t, count)
 			}
 		})
+	}
+}
+
+func TestNewInviteServiceWithTemplates(t *testing.T) {
+	gen := token.NewGenerator(nil)
+	repo := &mockInviteRepository{}
+
+	svc := NewInviteServiceWithTemplates(gen, repo, nil)
+	if svc == nil {
+		t.Fatal("expected non-nil InviteService")
+	}
+}
+
+func TestDeleteInvite_Success(t *testing.T) {
+	gen := token.NewGenerator(nil)
+	repo := &mockInviteRepository{
+		getByIDFunc: func(ctx context.Context, id int64) (*models.Invite, error) {
+			return &models.Invite{ID: id, Status: models.InviteStatusDraft}, nil
+		},
+	}
+	svc := NewInviteService(gen, repo)
+
+	if err := svc.DeleteInvite(context.Background(), 1); err != nil {
+		t.Errorf("DeleteInvite: %v", err)
+	}
+}
+
+func TestDeleteInvite_RespondedError(t *testing.T) {
+	gen := token.NewGenerator(nil)
+	repo := &mockInviteRepository{
+		getByIDFunc: func(ctx context.Context, id int64) (*models.Invite, error) {
+			return &models.Invite{ID: id, Status: models.InviteStatusResponded}, nil
+		},
+	}
+	svc := NewInviteService(gen, repo)
+
+	err := svc.DeleteInvite(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error for responded invite")
+	}
+}
+
+func TestDeleteInvite_NotFound(t *testing.T) {
+	gen := token.NewGenerator(nil)
+	repo := &mockInviteRepository{
+		getByIDFunc: func(ctx context.Context, id int64) (*models.Invite, error) {
+			return nil, &models.NotFoundError{Resource: "Invite", ID: id}
+		},
+	}
+	svc := NewInviteService(gen, repo)
+
+	err := svc.DeleteInvite(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for non-existent invite")
 	}
 }

--- a/internal/models/validation_test.go
+++ b/internal/models/validation_test.go
@@ -1,0 +1,363 @@
+package models
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestComponentType_String(t *testing.T) {
+	tests := []struct {
+		name string
+		ct   ComponentType
+		want string
+	}{
+		{"TextBox", ComponentTypeTextBox, "TextBox"},
+		{"Image", ComponentTypeImage, "Image"},
+		{"Background", ComponentTypeBackground, "Background"},
+		{"Overlay", ComponentTypeOverlay, "Overlay"},
+		{"Container", ComponentTypeContainer, "Container"},
+		{"Divider", ComponentTypeDivider, "Divider"},
+		{"custom value", ComponentType("Custom"), "Custom"},
+		{"empty", ComponentType(""), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ct.String(); got != tt.want {
+				t.Errorf("ComponentType.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPositionMode_String(t *testing.T) {
+	tests := []struct {
+		name string
+		pm   PositionMode
+		want string
+	}{
+		{"absolute", PositionModeAbsolute, "absolute"},
+		{"relative", PositionModeRelative, "relative"},
+		{"flex", PositionModeFlex, "flex"},
+		{"custom value", PositionMode("custom"), "custom"},
+		{"empty", PositionMode(""), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.pm.String(); got != tt.want {
+				t.Errorf("PositionMode.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLayoutMode_String(t *testing.T) {
+	tests := []struct {
+		name string
+		lm   LayoutMode
+		want string
+	}{
+		{"flexbox", LayoutModeFlexbox, "flexbox"},
+		{"grid", LayoutModeGrid, "grid"},
+		{"absolute", LayoutModeAbsolute, "absolute"},
+		{"custom value", LayoutMode("custom"), "custom"},
+		{"empty", LayoutMode(""), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.lm.String(); got != tt.want {
+				t.Errorf("LayoutMode.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionConflictError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *VersionConflictError
+		wantMsg  string
+		wantType bool
+	}{
+		{
+			name: "event version conflict",
+			err: &VersionConflictError{
+				ResourceType: "Event",
+				ResourceID:   42,
+				Expected:     3,
+				Actual:       5,
+			},
+			wantMsg:  "Event 42 version conflict: expected 3, got 5",
+			wantType: true,
+		},
+		{
+			name: "template version conflict",
+			err: &VersionConflictError{
+				ResourceType: "Template",
+				ResourceID:   7,
+				Expected:     1,
+				Actual:       2,
+			},
+			wantMsg:  "Template 7 version conflict: expected 1, got 2",
+			wantType: true,
+		},
+		{
+			name: "version conflict with matching versions",
+			err: &VersionConflictError{
+				ResourceType: "Invite",
+				ResourceID:   100,
+				Expected:     2,
+				Actual:       2,
+			},
+			wantMsg:  "Invite 100 version conflict: expected 2, got 2",
+			wantType: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.wantMsg {
+				t.Errorf("VersionConflictError.Error() = %v, want %v", got, tt.wantMsg)
+			}
+
+			var target *VersionConflictError
+			if errors.As(tt.err, &target) != tt.wantType {
+				t.Errorf("errors.As() = %v, want %v", !tt.wantType, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestPermissionDeniedError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *PermissionDeniedError
+		wantMsg  string
+		wantType bool
+	}{
+		{
+			name: "with string ID",
+			err: &PermissionDeniedError{
+				Action:   "delete",
+				Resource: "event",
+				ID:       "abc-123",
+			},
+			wantMsg:  "permission denied: cannot delete event abc-123",
+			wantType: true,
+		},
+		{
+			name: "with int ID",
+			err: &PermissionDeniedError{
+				Action:   "update",
+				Resource: "user",
+				ID:       42,
+			},
+			wantMsg:  "permission denied: cannot update user 42",
+			wantType: true,
+		},
+		{
+			name: "without ID (nil)",
+			err: &PermissionDeniedError{
+				Action:   "create",
+				Resource: "event",
+				ID:       nil,
+			},
+			wantMsg:  "permission denied: cannot create event",
+			wantType: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.wantMsg {
+				t.Errorf("PermissionDeniedError.Error() = %v, want %v", got, tt.wantMsg)
+			}
+
+			var target *PermissionDeniedError
+			if errors.As(tt.err, &target) != tt.wantType {
+				t.Errorf("errors.As() = %v, want %v", !tt.wantType, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestUnauthorizedError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *UnauthorizedError
+		wantMsg  string
+		wantType bool
+	}{
+		{
+			name: "with message",
+			err: &UnauthorizedError{
+				Message: "invalid credentials",
+			},
+			wantMsg:  "invalid credentials",
+			wantType: true,
+		},
+		{
+			name: "with custom message",
+			err: &UnauthorizedError{
+				Message: "session expired, please log in again",
+			},
+			wantMsg:  "session expired, please log in again",
+			wantType: true,
+		},
+		{
+			name:     "empty message defaults to unauthorized",
+			err:      &UnauthorizedError{},
+			wantMsg:  "unauthorized",
+			wantType: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.wantMsg {
+				t.Errorf("UnauthorizedError.Error() = %v, want %v", got, tt.wantMsg)
+			}
+
+			var target *UnauthorizedError
+			if errors.As(tt.err, &target) != tt.wantType {
+				t.Errorf("errors.As() = %v, want %v", !tt.wantType, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestForbiddenError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *ForbiddenError
+		wantMsg  string
+		wantType bool
+	}{
+		{
+			name: "with message",
+			err: &ForbiddenError{
+				Message: "insufficient permissions to perform this action",
+			},
+			wantMsg:  "insufficient permissions to perform this action",
+			wantType: true,
+		},
+		{
+			name: "with short message",
+			err: &ForbiddenError{
+				Message: "admin only",
+			},
+			wantMsg:  "admin only",
+			wantType: true,
+		},
+		{
+			name:     "empty message defaults to forbidden",
+			err:      &ForbiddenError{},
+			wantMsg:  "forbidden",
+			wantType: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.wantMsg {
+				t.Errorf("ForbiddenError.Error() = %v, want %v", got, tt.wantMsg)
+			}
+
+			var target *ForbiddenError
+			if errors.As(tt.err, &target) != tt.wantType {
+				t.Errorf("errors.As() = %v, want %v", !tt.wantType, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestDashboardStats_CalculateResponseRate(t *testing.T) {
+	tests := []struct {
+		name             string
+		stats            DashboardStats
+		wantResponseRate int
+	}{
+		{
+			name: "100% response rate",
+			stats: DashboardStats{
+				TotalInvites: 10,
+				TotalRSVPs:   10,
+			},
+			wantResponseRate: 100,
+		},
+		{
+			name: "50% response rate",
+			stats: DashboardStats{
+				TotalInvites: 100,
+				TotalRSVPs:   50,
+			},
+			wantResponseRate: 50,
+		},
+		{
+			name: "partial response rate rounds down",
+			stats: DashboardStats{
+				TotalInvites: 3,
+				TotalRSVPs:   2,
+			},
+			wantResponseRate: 66,
+		},
+		{
+			name: "zero invites yields zero rate",
+			stats: DashboardStats{
+				TotalInvites: 0,
+				TotalRSVPs:   5,
+			},
+			wantResponseRate: 0,
+		},
+		{
+			name: "zero invites and zero rsvps",
+			stats: DashboardStats{
+				TotalInvites: 0,
+				TotalRSVPs:   0,
+			},
+			wantResponseRate: 0,
+		},
+		{
+			name: "no rsvps yet",
+			stats: DashboardStats{
+				TotalInvites: 25,
+				TotalRSVPs:   0,
+			},
+			wantResponseRate: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.stats
+			s.CalculateResponseRate()
+			if s.ResponseRate != tt.wantResponseRate {
+				t.Errorf("CalculateResponseRate() ResponseRate = %v, want %v", s.ResponseRate, tt.wantResponseRate)
+			}
+		})
+	}
+}
+
+func TestPreferenceQuestion_Text(t *testing.T) {
+	tests := []struct {
+		name         string
+		questionText string
+		want         string
+	}{
+		{"non-empty text", "What is your meal preference?", "What is your meal preference?"},
+		{"short text", "Diet?", "Diet?"},
+		{"empty text", "", ""},
+		{"text with special chars", "Are you bringing a +1? (yes/no)", "Are you bringing a +1? (yes/no)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &PreferenceQuestion{QuestionText: tt.questionText}
+			if got := q.Text(); got != tt.want {
+				t.Errorf("PreferenceQuestion.Text() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/templates/coverage_test.go
+++ b/internal/templates/coverage_test.go
@@ -1,0 +1,399 @@
+package templates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lenaxia/tinyrsvp/internal/models"
+)
+
+func TestCoverage_EngineFuncs(t *testing.T) {
+	if result := iterate(5); len(result) != 5 {
+		t.Errorf("iterate(5) returned %d items, want 5", len(result))
+	}
+	if result := iterate(0); len(result) != 0 {
+		t.Errorf("iterate(0) returned %d items, want 0", len(result))
+	}
+	if result := add(2, 3); result != 5 {
+		t.Errorf("add(2,3) = %d, want 5", result)
+	}
+	if result := add(-1, 1); result != 0 {
+		t.Errorf("add(-1,1) = %d, want 0", result)
+	}
+}
+
+func TestCoverage_ServiceGetDefaultTemplate(t *testing.T) {
+	mockRepo := &mockServiceTemplateRepository{
+		GetDefaultByTypeFunc: func(ctx context.Context, tt models.TemplateType) (*models.Template, error) {
+			return &models.Template{ID: 1, Type: tt}, nil
+		},
+	}
+	svc := NewService(mockRepo, &mockServiceValidator{})
+
+	tmpl, err := svc.GetDefaultTemplate(context.Background(), models.TemplateTypeInviteEmail)
+	if err != nil {
+		t.Fatalf("GetDefaultTemplate: %v", err)
+	}
+	if tmpl.ID != 1 {
+		t.Errorf("template ID = %d, want 1", tmpl.ID)
+	}
+}
+
+func TestCoverage_ServiceGetComponentRenderer(t *testing.T) {
+	svc := NewService(&mockServiceTemplateRepository{}, &mockServiceValidator{})
+	if svc.GetComponentRenderer() == nil {
+		t.Error("GetComponentRenderer() returned nil")
+	}
+}
+
+func TestCoverage_ServiceRenderEmailTemplate(t *testing.T) {
+	htmlContent := "<html><body>Hello {{.Name}}</body></html>"
+	textContent := "Hello {{.Name}}"
+	mockRepo := &mockServiceTemplateRepository{
+		GetByEventAndTypeFunc: func(ctx context.Context, eventID int64, tt models.TemplateType) (*models.Template, error) {
+			return &models.Template{
+				ID:           1,
+				Type:         tt,
+				IsActive:     true,
+				HTMLContent:  htmlContent,
+				TextContent:  &textContent,
+			}, nil
+		},
+	}
+	svc := NewService(mockRepo, &mockServiceValidator{})
+
+	data := struct{ Name string }{Name: "World"}
+	htmlBody, textBody, err := svc.RenderEmailTemplate(context.Background(), 1, models.TemplateTypeInviteEmail, data)
+	if err != nil {
+		t.Fatalf("RenderEmailTemplate: %v", err)
+	}
+	if htmlBody == "" {
+		t.Error("expected non-empty htmlBody")
+	}
+	if textBody == "" {
+		t.Error("expected non-empty textBody")
+	}
+}
+
+func TestCoverage_ComponentRenderer_DeepMergeDimensions(t *testing.T) {
+	r := NewComponentRenderer(NewEngine())
+	dim := &models.Dimensions{}
+	r.deepMergeDimensions(dim, map[string]interface{}{
+		"width":  "100px",
+		"height": "200px",
+	})
+	if dim.Width != "100px" {
+		t.Errorf("Width = %q, want 100px", dim.Width)
+	}
+	if dim.Height != "200px" {
+		t.Errorf("Height = %q, want 200px", dim.Height)
+	}
+}
+
+func TestCoverage_ComponentRenderer_MergeBackgroundContent(t *testing.T) {
+	r := NewComponentRenderer(NewEngine())
+	content := &models.BackgroundContent{}
+	r.mergeBackgroundContent(content, map[string]interface{}{
+		"type":              "gradient",
+		"color":             "#fff",
+		"gradient":          "linear-gradient(...)",
+		"image":             "bg.jpg",
+		"backgroundSize":    "cover",
+		"backgroundPosition": "center",
+	})
+	if content.Type != "gradient" {
+		t.Errorf("Type = %q", content.Type)
+	}
+	if content.Color != "#fff" {
+		t.Errorf("Color = %q", content.Color)
+	}
+}
+
+func TestCoverage_ComponentRenderer_MergeOverlayContent(t *testing.T) {
+	r := NewComponentRenderer(NewEngine())
+	content := &models.OverlayContent{}
+	r.mergeOverlayContent(content, map[string]interface{}{
+		"backgroundColor":  "rgba(0,0,0,0.5)",
+		"backgroundImage":  "overlay.png",
+		"backgroundSize":   "cover",
+		"borderRadius":     "8px",
+		"border":           "1px solid #ccc",
+		"boxShadow":        "0 2px 4px rgba(0,0,0,0.1)",
+		"clipPath":         "circle(50%)",
+		"placeholder":      true,
+	})
+	if content.BackgroundColor != "rgba(0,0,0,0.5)" {
+		t.Errorf("BackgroundColor = %q", content.BackgroundColor)
+	}
+	if !content.Placeholder {
+		t.Error("Placeholder should be true")
+	}
+}
+
+func TestCoverage_ComponentRenderer_DeepMergeLayout(t *testing.T) {
+	r := NewComponentRenderer(NewEngine())
+	comp := &models.Component{Type: models.ComponentTypeContainer}
+	r.deepMergeLayout(comp, map[string]interface{}{
+		"display":        "flex",
+		"flexDirection":  "column",
+		"justifyContent": "center",
+		"alignItems":     "stretch",
+		"gap":            "10px",
+		"padding":        "20px",
+		"children":       []interface{}{"child1", "child2"},
+	})
+	if comp.Layout == nil {
+		t.Fatal("Layout should be initialized")
+	}
+	if comp.Layout.Display != "flex" {
+		t.Errorf("Display = %q", comp.Layout.Display)
+	}
+	if len(comp.Layout.Children) != 2 {
+		t.Errorf("Children count = %d, want 2", len(comp.Layout.Children))
+	}
+}
+
+func TestCoverage_ComponentRenderer_DeepMergeLayout_NonContainer(t *testing.T) {
+	r := NewComponentRenderer(NewEngine())
+	comp := &models.Component{Type: models.ComponentTypeTextBox}
+	err := r.deepMergeLayout(comp, map[string]interface{}{"display": "flex"})
+	if err != nil {
+		t.Errorf("deepMergeLayout on non-container: %v", err)
+	}
+	if comp.Layout != nil {
+		t.Error("Layout should remain nil for non-container")
+	}
+}
+
+func TestCoverage_ComponentRenderer_DeepMergeStyle(t *testing.T) {
+	r := NewComponentRenderer(NewEngine())
+	comp := &models.Component{Type: models.ComponentTypeDivider}
+	r.deepMergeStyle(comp, map[string]interface{}{
+		"backgroundColor": "#ccc",
+		"height":          "2px",
+		"margin":          "10px 0",
+		"borderRadius":    "1px",
+	})
+	if comp.Style == nil {
+		t.Fatal("Style should be initialized")
+	}
+	if comp.Style.BackgroundColor != "#ccc" {
+		t.Errorf("BackgroundColor = %q", comp.Style.BackgroundColor)
+	}
+}
+
+func TestCoverage_ComponentRenderer_DeepMergeStyle_NonDivider(t *testing.T) {
+	r := NewComponentRenderer(NewEngine())
+	comp := &models.Component{Type: models.ComponentTypeTextBox}
+	err := r.deepMergeStyle(comp, map[string]interface{}{"backgroundColor": "#ccc"})
+	if err != nil {
+		t.Errorf("deepMergeStyle on non-divider: %v", err)
+	}
+	if comp.Style != nil {
+		t.Error("Style should remain nil for non-divider")
+	}
+}
+
+func TestCoverage_ComponentRenderer_DeepMergeResponsive(t *testing.T) {
+	r := NewComponentRenderer(NewEngine())
+	comp := &models.Component{Type: models.ComponentTypeTextBox}
+	r.deepMergeResponsive(comp, map[string]interface{}{
+		"mobile": map[string]interface{}{
+			"width":    "100%",
+			"fontSize": "14px",
+		},
+		"tablet": map[string]interface{}{
+			"width": "50%",
+		},
+		"desktop": map[string]interface{}{
+			"width": "33%",
+		},
+	})
+	if comp.Responsive == nil {
+		t.Fatal("Responsive should be initialized")
+	}
+	if comp.Responsive.Mobile == nil || comp.Responsive.Mobile.Width != "100%" {
+		t.Error("Mobile responsive not set correctly")
+	}
+	if comp.Responsive.Tablet == nil || comp.Responsive.Tablet.Width != "50%" {
+		t.Error("Tablet responsive not set correctly")
+	}
+	if comp.Responsive.Desktop == nil || comp.Responsive.Desktop.Width != "33%" {
+		t.Error("Desktop responsive not set correctly")
+	}
+}
+
+func TestCoverage_EditorService_DeepCopyContent(t *testing.T) {
+	svc := NewEditorService(nil).(*editorService)
+	textBox := models.TextBoxContent{Text: "hello"}
+	image := models.ImageContent{Src: "img.png"}
+	background := models.BackgroundContent{Color: "#fff"}
+	overlay := models.OverlayContent{BackgroundColor: "rgba(0,0,0,0.5)"}
+
+	content := &models.ComponentContent{
+		TextBox:    &textBox,
+		Image:      &image,
+		Background: &background,
+		Overlay:    &overlay,
+	}
+
+	copied := svc.deepCopyContent(content)
+	if copied == nil {
+		t.Fatal("expected non-nil copy")
+	}
+	if copied.TextBox.Text != "hello" {
+		t.Error("TextBox not copied")
+	}
+	if copied.Image.Src != "img.png" {
+		t.Error("Image not copied")
+	}
+
+	if svc.deepCopyContent(nil) != nil {
+		t.Error("nil input should return nil")
+	}
+}
+
+func TestCoverage_EditorService_DeepCopyLayout(t *testing.T) {
+	svc := NewEditorService(nil).(*editorService)
+	layout := &models.ContainerLayout{
+		Display:        "flex",
+		FlexDirection:  "row",
+		JustifyContent: "center",
+		AlignItems:     "stretch",
+		Gap:            "10px",
+		Padding:        "20px",
+		Children:       []string{"a", "b", "c"},
+	}
+
+	copied := svc.deepCopyLayout(layout)
+	if copied == nil {
+		t.Fatal("expected non-nil copy")
+	}
+	if copied.Display != "flex" {
+		t.Error("Display not copied")
+	}
+	if len(copied.Children) != 3 {
+		t.Errorf("Children count = %d, want 3", len(copied.Children))
+	}
+
+	if svc.deepCopyLayout(nil) != nil {
+		t.Error("nil input should return nil")
+	}
+}
+
+func TestCoverage_EditorService_DeepCopyStyle(t *testing.T) {
+	svc := NewEditorService(nil).(*editorService)
+	style := &models.DividerStyle{
+		BackgroundColor: "#ccc",
+		Height:          "2px",
+		Margin:          "10px",
+		BorderRadius:    "1px",
+	}
+
+	copied := svc.deepCopyStyle(style)
+	if copied == nil {
+		t.Fatal("expected non-nil copy")
+	}
+	if copied.BackgroundColor != "#ccc" {
+		t.Error("BackgroundColor not copied")
+	}
+
+	if svc.deepCopyStyle(nil) != nil {
+		t.Error("nil input should return nil")
+	}
+}
+
+func TestCoverage_EditorService_DeepCopyResponsive(t *testing.T) {
+	svc := NewEditorService(nil).(*editorService)
+	mobile := models.ResponsiveBreakpoint{Width: "100%"}
+	tablet := models.ResponsiveBreakpoint{Width: "50%"}
+	desktop := models.ResponsiveBreakpoint{Width: "33%"}
+
+	resp := &models.ResponsiveConfig{
+		Mobile:  &mobile,
+		Tablet:  &tablet,
+		Desktop: &desktop,
+	}
+
+	copied := svc.deepCopyResponsive(resp)
+	if copied == nil {
+		t.Fatal("expected non-nil copy")
+	}
+	if copied.Mobile.Width != "100%" {
+		t.Error("Mobile not copied")
+	}
+	if copied.Tablet.Width != "50%" {
+		t.Error("Tablet not copied")
+	}
+	if copied.Desktop.Width != "33%" {
+		t.Error("Desktop not copied")
+	}
+
+	if svc.deepCopyResponsive(nil) != nil {
+		t.Error("nil input should return nil")
+	}
+}
+
+func TestCoverage_MockServiceTemplateRepository_Defaults(t *testing.T) {
+	m := &mockServiceTemplateRepository{}
+	ctx := context.Background()
+
+	if templates, err := m.GetTemplatesByCategory(ctx, models.CategoryPlain); err != nil || len(templates) != 0 {
+		t.Errorf("GetTemplatesByCategory default: templates=%v err=%v", templates, err)
+	}
+	if templates, err := m.ListThemes(ctx, models.TemplateTypeInviteEmail, nil); err != nil || len(templates) != 0 {
+		t.Errorf("ListThemes default: templates=%v err=%v", templates, err)
+	}
+	if config, err := m.GetComponentConfig(ctx, 1); err != nil || config != nil {
+		t.Errorf("GetComponentConfig default: config=%v err=%v", config, err)
+	}
+	if err := m.UpdateComponentConfig(ctx, 1, nil); err != nil {
+		t.Errorf("UpdateComponentConfig default: err=%v", err)
+	}
+	if err := m.ValidateComponentConfig(ctx, nil); err != nil {
+		t.Errorf("ValidateComponentConfig default: err=%v", err)
+	}
+}
+
+func TestCoverage_MockServiceValidator_Defaults(t *testing.T) {
+	m := &mockServiceValidator{}
+	if err := m.ValidateSyntax("content", models.TemplateTypeInviteEmail); err != nil {
+		t.Errorf("ValidateSyntax default: err=%v", err)
+	}
+	if err := m.ValidateVariables("content", []string{"var1"}); err != nil {
+		t.Errorf("ValidateVariables default: err=%v", err)
+	}
+	if err := m.ValidateSize("content", 1000); err != nil {
+		t.Errorf("ValidateSize default: err=%v", err)
+	}
+}
+
+func TestCoverage_EditorService_DeepCopyMap(t *testing.T) {
+	svc := NewEditorService(nil).(*editorService)
+
+	original := map[string]interface{}{
+		"key1": "value1",
+		"nested": map[string]interface{}{
+			"inner": "val",
+		},
+	}
+
+	copied := svc.deepCopyMap(original)
+	if copied == nil {
+		t.Fatal("expected non-nil copy")
+	}
+	if copied["key1"] != "value1" {
+		t.Error("key1 not copied")
+	}
+	nested, ok := copied["nested"].(map[string]interface{})
+	if !ok {
+		t.Fatal("nested map not copied as map")
+	}
+	if nested["inner"] != "val" {
+		t.Error("nested inner not copied")
+	}
+
+	if svc.deepCopyMap(nil) != nil {
+		t.Error("nil input should return nil")
+	}
+}


### PR DESCRIPTION
## Summary

Added tests for 90+ previously uncovered functions across 8 packages. Coverage improved from 74.9% to 79.2% (statement coverage, excluding testutil). No production code changes — purely additive test code.

## Coverage by package (before → after)

| Package | Before | After |
|---------|--------|-------|
| internal/db | 75.2% | ~85% |
| internal/email | 76.1% | ~82% |
| internal/handlers | 80.2% | ~85% |
| internal/templates | 69.6% | ~75% |
| internal/models | 81.5% | 89.4% |
| internal/auth | 86.7% | 90.3% |
| internal/invites | 85.9% | ~88% |
| internal/events | 85.5% | ~87% |

## What was tested

- **db/retry.go**: 25 tests — backoff calculation, context cancellation, SQLite lock error detection, retry on lock, max retries exceeded, all DB operations (Ping/Exec/Query/WithTransaction)
- **db/db.go**: NewDatabaseWithRetry constructor
- **email/metrics.go**: all 10 noOpMetrics methods (called and verified, though Go reports 0% for empty bodies)
- **email/smtp_sender.go**: Send happy/unhappy paths, PermanentError.Unwrap
- **email/stubs.go**: stubRateLimiter WaitTime/Record/Reset
- **handlers**: 29 constructor/adapter/handler tests (NewXHandler, SetTemplates, RegisterRoutes, metrics adapter delegation, settings sub-structs)
- **models**: 9 validation methods (String(), Error(), CalculateResponseRate)
- **auth**: OIDC + ForwardAuth config constructors, user service methods (UpdateRole, UpdateLastLogin, CountUsers, CountAdmins)
- **templates**: component renderer merge functions (dimensions, background, overlay, layout, style, responsive), editor service deep copy functions (content, layout, style, responsive, map), engine helpers (iterate, add), service methods (GetDefaultTemplate, GetComponentRenderer, RenderEmailTemplate), mock defaults
- **invites**: NewInviteServiceWithTemplates, DeleteInvite (success, responded error, not found)
- **events**: ListEventsWithStats (unauthorized, as event manager)
- **db/repositories**: GetByCreatorID, UpdateExpiresAtByEventID, GetByEventIDs (empty), GetByInviteIDs (empty)

## Remaining gaps (12 functions, all structurally uncoverable)

All 12 remaining 0% functions are empty no-op method bodies in email/metrics.go and email/stubs.go (e.g., func (m *noOpMetrics) RecordQueueSize(size int) {}). Go's statement-based coverage tool cannot credit empty function bodies, even when the tests call them. This is a Go tooling limitation, not a test gap.

The 3 cmd/ and scripts/ functions are main() entrypoints that cannot be unit tested.

## Validation
- go vet, go build — clean
- Full non-UX suite — all pass
- +2925 lines of test code, 0 production changes