### PR TITLE
fix: make event end datetime opt-in and prevent end before start

### DIFF
--- a/docs/01_WORKLOG/0177_2026-07-24_event_datetime_picker_end_opt_in.md
+++ b/docs/01_WORKLOG/0177_2026-07-24_event_datetime_picker_end_opt_in.md
@@ -1,0 +1,89 @@
+# Worklog: Event Datetime Picker — End Time Opt-in & Start-Before-End Prevention
+
+**Date:** 2026-07-24  
+**PR:** [#54](https://github.com/lenaxia/TinyRSVP/pull/54)
+
+## Summary
+
+Reworked the shared datetime picker so the event end datetime is opt-in (start-only by default), clearable, and impossible to set before the start datetime. Backend validation was already correct; this was a picker UX fix.
+
+## Work Completed
+
+- [x] `date_defaults.js` no longer pre-fills `end_time` (start-only default); removed now-dead `getDefaultEndTime`.
+- [x] Added "Add end time" checkbox to the shared picker panel (`datetime_picker_panel.html`, mirrored in `static/datetime_picker_test.html`).
+- [x] Reworked `datetime_picker.js`: `showEndTime` is now a dynamic per-instance property (default off) toggled by the checkbox via a new `toggleEndTime()` method; Start/End tabs only render once end is enabled; hidden for `datetime-single`/`date-only` pickers.
+- [x] Unchecking the box clears the end selection; `saveDateTime()` writes an empty `end_time` (web handler already maps empty → `EndTime = nil`).
+- [x] Added three client-side layers preventing end-before-start: end calendar disables days before start, end time list disables slots `<=` start on the same day, and moving start date/time to invalidate an existing end auto-clears it.
+- [x] CSS for the checkbox toggle and disabled time options.
+- [x] Updated 3 existing chromedp tests whose assertions encoded the old "end always visible" behavior; added a checkbox-enable step before clicking the End tab in the two range-selection tests.
+- [x] Added 4 new chromedp tests (end disabled by default, enabling end shows toggle group, unchecking clears `end_time`, end calendar disables pre-start days, moving start past end clears end).
+- [x] Updated Jest-style fixtures/assertions (`datetime_picker_test.js`) to include the checkbox and flip range-mode visibility expectations.
+
+## Decisions Made
+
+### Decision 1: Checkbox vs. an "Add end time" button vs. auto-show-on-first-end-interaction
+**Context:** Needed a mechanism to enable the optional end datetime and to clear it.  
+**Options Considered:**
+- Checkbox — standard, clearly conveys on/off state, accessible.
+- Button that toggles to "Remove end time" — slightly more prominent but ambiguous state.
+- Auto-show when user clicks an empty End tab — discoverable but cannot be "cleared" once set without an explicit control.
+
+**Decision:** Checkbox — it doubles as both the enable and the clear control and is the most accessible/idiomatic. Hidden for non-range pickers.
+
+### Decision 2: How strictly to prevent end-before-start
+**Context:** The server (`validator.go:230`) and a SQLite CHECK already reject end ≤ start, but the picker allowed constructing such a range, erroring only on submit.  
+**Options Considered:**
+- Validate only on save (block save with an inline error) — least code, but poor UX.
+- Disable invalid days/times in the calendar/time list — prevents the error at selection time.
+- Disable AND auto-clear an existing end if start moves past it — fully prevents stale invalid state.
+
+**Decision:** Disable invalid options (days before start; same-day times ≤ start) AND auto-clear via `_clearEndIfInvalid` when start moves. Belt-and-suspenders so the user never reaches the server-side error.
+
+### Decision 3: No backend change
+**Context:** `validateEndTime` and the DB CHECK already enforced `end > start`, and `UpdateEventFromForm` already maps an empty `end_time` to `EndTime = nil`.  
+**Decision:** Frontend-only change — no backend/schema/handler changes needed, minimizing blast radius.
+
+## Blockers
+
+- None.
+
+## Next Steps
+
+- Merge PR #54 after review approval.
+
+## Files Changed
+
+- `static/js/date_defaults.js` — removed default `end_time` prefill and dead `getDefaultEndTime`.
+- `static/js/datetime_picker.js` — dynamic `showEndTime`, `toggleEndTime()`, end-before-start prevention (calendar/time-list disable + auto-clear), clear-end-on-disable.
+- `templates/web/partials/datetime_picker_panel.html` — added the "Add end time" checkbox.
+- `static/datetime_picker_test.html` — mirrored the checkbox in the test fixture.
+- `static/css/datetime_picker.css` — styles for `.datetime-end-toggle`/`.datetime-end-checkbox`/`.time-option.disabled`.
+- `static/js/datetime_picker_test.go` — updated 3 tests, added 4 tests.
+- `static/js/datetime_picker_test.js` — added checkbox to fixtures, flipped assertions, added enable step.
+
+## Tests
+
+- [x] `go build ./...` clean
+- [x] `go vet ./static/js/ ./templates/... ./internal/events/... ./internal/handlers/...` clean
+- [x] `go test ./internal/events/...` — pass
+- [x] `go test ./internal/handlers/...` — pass
+- [x] `go test ./templates/...` — pass (including modified partial)
+- [x] `go test ./static/js/` — compiles clean; chromedp tests skip in this sandbox (no Chrome at localhost:8080) and run in the dev environment.
+
+## Notes
+
+- The pre-existing `.github/workflows/*.yml` modifications in the working tree were intentionally excluded from this PR.
+- README-LLM.md stated "Next Entry: Use 0176" but `0176_*` already existed; used 0177 instead. The README index is stale (shows count 141 / range 0000-0140) and was not updated as part of this work.
+
+## References
+
+- PR: https://github.com/lenaxia/TinyRSVP/pull/54
+- Backend validation (unchanged): `internal/events/validator.go:230` (`validateEndTime`)
+- Form parse mapping empty end → nil: `internal/handlers/events_web.go:344`
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** All runnable tests pass; browser tests skip in CI-less sandbox  
+**Confidence:** HIGH  
+**Production Ready:** Yes

--- a/static/css/datetime_picker.css
+++ b/static/css/datetime_picker.css
@@ -150,6 +150,28 @@
     z-index: 1;
 }
 
+.datetime-end-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    padding: var(--spacing-2) 0 var(--spacing-3);
+    cursor: pointer;
+    user-select: none;
+}
+
+.datetime-end-checkbox {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: var(--color-primary);
+}
+
+.datetime-end-toggle-label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-secondary);
+}
+
 .datetime-toggle-btn {
     flex: 1;
     padding: var(--spacing-3) var(--spacing-4);
@@ -367,6 +389,17 @@
 .time-option.selected:hover {
     background: var(--color-primary-700);
     border-color: var(--color-primary-800);
+}
+
+.time-option.disabled {
+    color: var(--color-text-tertiary);
+    cursor: not-allowed;
+    text-decoration: line-through;
+}
+
+.time-option.disabled:hover {
+    background: transparent;
+    border-color: transparent;
 }
 
 .timezone-display {

--- a/static/datetime_picker_test.html
+++ b/static/datetime_picker_test.html
@@ -105,6 +105,10 @@
             <button class="datetime-picker-close" aria-label="Close date picker">×</button>
         </div>
         <div class="datetime-picker-body">
+            <label class="datetime-end-toggle">
+                <input type="checkbox" class="datetime-end-checkbox">
+                <span class="datetime-end-toggle-label">Add end time</span>
+            </label>
             <div class="datetime-toggle-group">
                 <button type="button" class="datetime-toggle-btn active" data-mode="start">
                     <span class="datetime-toggle-label">Start Time</span>

--- a/static/js/date_defaults.js
+++ b/static/js/date_defaults.js
@@ -14,13 +14,6 @@ const DateDefaults = {
         return this.formatDateTimeLocal(now);
     },
 
-    getDefaultEndTime() {
-        const now = new Date();
-        now.setDate(now.getDate() + 7);
-        now.setHours(21, 0, 0, 0);
-        return this.formatDateTimeLocal(now);
-    },
-
     getDefaultRSVPDeadline() {
         const now = new Date();
         now.setDate(now.getDate() + 5);
@@ -93,15 +86,10 @@ const DateDefaults = {
 
     setDateDefaults() {
         const startTimeInput = document.getElementById('start_time');
-        const endTimeInput = document.getElementById('end_time');
         const rsvpDeadlineInput = document.getElementById('rsvp_deadline');
 
         if (startTimeInput && !startTimeInput.value) {
             startTimeInput.value = this.getDefaultStartTime();
-        }
-
-        if (endTimeInput && !endTimeInput.value) {
-            endTimeInput.value = this.getDefaultEndTime();
         }
 
         if (rsvpDeadlineInput && !rsvpDeadlineInput.value) {

--- a/static/js/datetime_picker.js
+++ b/static/js/datetime_picker.js
@@ -60,6 +60,11 @@
             btn.addEventListener('click', () => activeInstance && activeInstance.openTimezonePanel());
         });
 
+        const endCheckbox = document.querySelector('.datetime-end-checkbox');
+        if (endCheckbox) {
+            endCheckbox.addEventListener('change', () => activeInstance && activeInstance.toggleEndTime(endCheckbox.checked));
+        }
+
         if (tzPanel) {
             tzCloseBtn && tzCloseBtn.addEventListener('click', () => activeInstance && activeInstance.closeTimezonePanel());
             tzOverlay && tzOverlay.addEventListener('click', () => activeInstance && activeInstance.closeTimezonePanel());
@@ -90,7 +95,6 @@
             this.config = {
                 mode,
                 showTimezone:    triggerEl.dataset.showTimezone !== 'false',
-                showEndTime:     mode === 'datetime-range',
                 triggerEl,
                 startInputId:    triggerEl.dataset.startInput  || triggerEl.id,
                 endInputId:      triggerEl.dataset.endInput     || null,
@@ -109,11 +113,14 @@
             this.currentMonth      = new Date();
             this.today             = new Date();
             this.today.setHours(0, 0, 0, 0);
+            this.showEndTime       = false;
 
             if (!panel || !overlay) return;
 
             this._bindTrigger();
             this._loadExistingValues();
+            this.showEndTime = this.config.mode === 'datetime-range' && this.selectedEndDate !== null;
+            if (this.selectedStartDate) this._updateTriggerDisplay();
         }
 
         // ---- private --------------------------------------------------------
@@ -167,7 +174,7 @@
             // causing the user to interact with stale content from the previous instance.
             this.switchMode(this.currentMode);
             if (this.config.showTimezone)  this._updateTimezoneDisplay();
-            if (this.config.showEndTime)   this._updateToggleDisplays();
+            if (this.showEndTime)          this._updateToggleDisplays();
         }
 
         closePanel() {
@@ -191,6 +198,7 @@
         }
 
         switchMode(mode) {
+            if (mode === 'end' && !this.showEndTime) mode = 'start';
             this.currentMode = mode;
             document.querySelectorAll('.datetime-toggle-btn').forEach(btn => {
                 btn.classList.toggle('active', btn.dataset.mode === mode);
@@ -200,6 +208,19 @@
             });
             this.renderCalendar();
             if (this.config.mode !== 'date-only') this.renderTimePicker();
+        }
+
+        toggleEndTime(enabled) {
+            if (this.config.mode !== 'datetime-range') return;
+            this.showEndTime = !!enabled;
+            if (!this.showEndTime) {
+                this.selectedEndDate = null;
+                this.selectedEndTime = null;
+            }
+            this._updateUIForMode();
+            this.switchMode(this.showEndTime ? 'end' : 'start');
+            this._updateToggleDisplays();
+            this._updateTriggerDisplay();
         }
 
         navigateMonth(direction) {
@@ -261,6 +282,7 @@
             if (!timeScroll) return;
 
             timeScroll.innerHTML = '';
+            const disableBefore = this._endSameDayMinDateTime();
             for (let hour = 0; hour < 24; hour++) {
                 for (let minute = 0; minute < 60; minute += 15) {
                     const timeStr   = this._formatTimeOption(hour, minute);
@@ -274,11 +296,15 @@
                         setTimeout(() => timeOption.scrollIntoView({ block: 'center', behavior: 'smooth' }), 100);
                     }
 
-                    timeOption.addEventListener('click', (e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        this._selectTime(timeStr);
-                    });
+                    if (disableBefore && this._combineDateAndTime(this.selectedEndDate, timeStr) <= disableBefore) {
+                        timeOption.classList.add('disabled');
+                    } else {
+                        timeOption.addEventListener('click', (e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            this._selectTime(timeStr);
+                        });
+                    }
                     timeScroll.appendChild(timeOption);
                 }
             }
@@ -298,12 +324,12 @@
                 }
             }
 
-            if (endInput && this.selectedEndDate) {
-                if (this.config.mode === 'date-only') {
-                    endInput.value = this._formatDateForInput(this.selectedEndDate);
-                } else if (this.selectedEndTime) {
+            if (endInput) {
+                if (this.showEndTime && this.selectedEndDate && this.selectedEndTime) {
                     const dt = this._combineDateAndTime(this.selectedEndDate, this.selectedEndTime);
                     endInput.value = this._formatForInput(dt);
+                } else {
+                    endInput.value = '';
                 }
             }
 
@@ -332,10 +358,16 @@
         }
 
         _updateUIForMode() {
+            const isRange = this.config.mode === 'datetime-range';
+
+            const endToggle = panel.querySelector('.datetime-end-toggle');
+            if (endToggle) endToggle.style.display = isRange ? '' : 'none';
+
+            const endCheckbox = panel.querySelector('.datetime-end-checkbox');
+            if (endCheckbox) endCheckbox.checked = this.showEndTime;
+
             const toggleGroup = panel.querySelector('.datetime-toggle-group');
-            if (toggleGroup) {
-                toggleGroup.style.display = this.config.showEndTime ? 'flex' : 'none';
-            }
+            if (toggleGroup) toggleGroup.style.display = this.showEndTime ? 'flex' : 'none';
 
             panel.querySelectorAll('.timezone-display').forEach(el => {
                 el.style.display = this.config.showTimezone ? '' : 'none';
@@ -354,8 +386,15 @@
             const dayDate = new Date(year, month, dayNum);
             dayDate.setHours(0, 0, 0, 0);
 
+            let minDate = this.today;
+            if (this.currentMode === 'end' && this.selectedStartDate) {
+                const startDay = new Date(this.selectedStartDate);
+                startDay.setHours(0, 0, 0, 0);
+                minDate = startDay;
+            }
+
             if (isOtherMonth) day.classList.add('other-month');
-            if (dayDate < this.today) day.classList.add('disabled');
+            if (dayDate < minDate) day.classList.add('disabled');
             if (dayDate.getTime() === this.today.getTime()) day.classList.add('today');
 
             const selectedDate = this.currentMode === 'start' ? this.selectedStartDate : this.selectedEndDate;
@@ -365,7 +404,7 @@
                 if (dayDate.getTime() === sel.getTime()) day.classList.add('selected');
             }
 
-            if (!isOtherMonth && dayDate >= this.today) {
+            if (!isOtherMonth && dayDate >= minDate) {
                 day.style.cursor = 'pointer';
                 day.addEventListener('click', (e) => {
                     e.preventDefault();
@@ -382,22 +421,29 @@
             if (this.currentMode === 'start') {
                 this.selectedStartDate = newDate;
                 if (!this.selectedStartTime && this.config.mode !== 'date-only') this.selectedStartTime = '12:00 PM';
+                if (this.showEndTime) this._clearEndIfInvalid();
             } else {
                 this.selectedEndDate = newDate;
                 if (!this.selectedEndTime && this.config.mode !== 'date-only') this.selectedEndTime = '12:00 PM';
+                if (this.selectedStartDate && this._sameDay(this.selectedStartDate, newDate) && this.selectedStartTime) {
+                    const startDT = this._combineDateAndTime(this.selectedStartDate, this.selectedStartTime);
+                    const endDT   = this._combineDateAndTime(newDate, this.selectedEndTime);
+                    if (endDT <= startDT) this.selectedEndTime = null;
+                }
             }
             this.renderCalendar();            if (this.config.mode !== 'date-only') this.renderTimePicker();
-            if (this.config.showEndTime) this._updateToggleDisplays();
+            if (this.showEndTime) this._updateToggleDisplays();
         }
 
         _selectTime(timeStr) {
             if (this.currentMode === 'start') {
                 this.selectedStartTime = timeStr;
+                if (this.showEndTime) this._clearEndIfInvalid();
             } else {
                 this.selectedEndTime = timeStr;
             }
             this.renderTimePicker();
-            if (this.config.showEndTime) this._updateToggleDisplays();
+            if (this.showEndTime) this._updateToggleDisplays();
         }
 
         _updateTimezoneDisplay() {
@@ -434,7 +480,7 @@
 
                 let displayText = startStr;
 
-                if (this.config.showEndTime && this.selectedEndDate && this.selectedEndTime) {
+                if (this.showEndTime && this.selectedEndDate && this.selectedEndTime) {
                     const fmt = { year: 'numeric', month: '2-digit', day: '2-digit' };
                     if (this.selectedStartDate.toLocaleDateString('en-US', fmt) !==
                         this.selectedEndDate.toLocaleDateString('en-US', fmt)) {
@@ -484,6 +530,29 @@
             const result = new Date(date);
             result.setHours(hour, minute, 0, 0);
             return result;
+        }
+
+        _sameDay(a, b) {
+            return a.getFullYear() === b.getFullYear()
+                && a.getMonth() === b.getMonth()
+                && a.getDate() === b.getDate();
+        }
+
+        _endSameDayMinDateTime() {
+            if (this.currentMode !== 'end') return null;
+            if (!this.selectedStartDate || !this.selectedStartTime || !this.selectedEndDate) return null;
+            if (!this._sameDay(this.selectedStartDate, this.selectedEndDate)) return null;
+            return this._combineDateAndTime(this.selectedStartDate, this.selectedStartTime);
+        }
+
+        _clearEndIfInvalid() {
+            if (!this.selectedStartDate || !this.selectedEndDate) return;
+            const startDT = this._combineDateAndTime(this.selectedStartDate, this.selectedStartTime || '12:00 AM');
+            const endDT   = this._combineDateAndTime(this.selectedEndDate, this.selectedEndTime || '12:00 AM');
+            if (endDT <= startDT) {
+                this.selectedEndDate = null;
+                this.selectedEndTime = null;
+            }
         }
 
         _formatForInput(date) {

--- a/static/js/datetime_picker_test.go
+++ b/static/js/datetime_picker_test.go
@@ -35,7 +35,45 @@ func TestDateTimePickerSingleMode(t *testing.T) {
 	}
 }
 
-func TestDateTimePickerRangeMode(t *testing.T) {
+func TestDateTimePickerRangeModeEndDisabledByDefault(t *testing.T) {
+	requireServer(t)
+	ctx, cancel := chromedp.NewContext(context.Background())
+	defer cancel()
+
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	var toggleGroupDisplay, endToggleDisplay string
+	var endCheckboxChecked bool
+	err := chromedp.Run(ctx,
+		chromedp.Navigate("http://localhost:8080/static/datetime_picker_test.html"),
+		chromedp.WaitVisible(`#event_datetime_trigger`, chromedp.ByID),
+		chromedp.Click(`#event_datetime_trigger`, chromedp.ByID),
+		chromedp.WaitVisible(`.datetime-picker-panel.open`, chromedp.ByQuery),
+		chromedp.Sleep(500*time.Millisecond),
+		chromedp.Evaluate(`window.getComputedStyle(document.querySelector('.datetime-toggle-group')).display`, &toggleGroupDisplay),
+		chromedp.Evaluate(`window.getComputedStyle(document.querySelector('.datetime-end-toggle')).display`, &endToggleDisplay),
+		chromedp.Evaluate(`document.querySelector('.datetime-end-checkbox').checked`, &endCheckboxChecked),
+	)
+
+	if err != nil {
+		t.Fatalf("Failed to run test: %v", err)
+	}
+
+	if toggleGroupDisplay != "none" {
+		t.Errorf("Expected toggle group hidden by default (end disabled), got display: %s", toggleGroupDisplay)
+	}
+
+	if endToggleDisplay == "none" {
+		t.Errorf("Expected 'Add end time' checkbox visible for datetime-range mode, got display: %s", endToggleDisplay)
+	}
+
+	if endCheckboxChecked {
+		t.Error("Expected 'Add end time' checkbox unchecked by default")
+	}
+}
+
+func TestDateTimePickerEnablingEndShowsToggleGroup(t *testing.T) {
 	requireServer(t)
 	ctx, cancel := chromedp.NewContext(context.Background())
 	defer cancel()
@@ -44,13 +82,18 @@ func TestDateTimePickerRangeMode(t *testing.T) {
 	defer cancel()
 
 	var toggleGroupDisplay string
+	var activeContent string
 	err := chromedp.Run(ctx,
 		chromedp.Navigate("http://localhost:8080/static/datetime_picker_test.html"),
 		chromedp.WaitVisible(`#event_datetime_trigger`, chromedp.ByID),
 		chromedp.Click(`#event_datetime_trigger`, chromedp.ByID),
 		chromedp.WaitVisible(`.datetime-picker-panel.open`, chromedp.ByQuery),
 		chromedp.Sleep(500*time.Millisecond),
+		// Enable end time via the checkbox
+		chromedp.Evaluate(`document.querySelector('.datetime-end-checkbox').click()`, nil),
+		chromedp.Sleep(400*time.Millisecond),
 		chromedp.Evaluate(`window.getComputedStyle(document.querySelector('.datetime-toggle-group')).display`, &toggleGroupDisplay),
+		chromedp.Evaluate(`document.querySelector('.datetime-picker-content.active')?.dataset?.content || 'none'`, &activeContent),
 	)
 
 	if err != nil {
@@ -58,7 +101,11 @@ func TestDateTimePickerRangeMode(t *testing.T) {
 	}
 
 	if toggleGroupDisplay == "none" {
-		t.Errorf("Expected toggle group to be visible for datetime-range mode, got display: %s", toggleGroupDisplay)
+		t.Errorf("Expected toggle group visible after enabling end time, got display: %s", toggleGroupDisplay)
+	}
+
+	if activeContent != "end" {
+		t.Errorf("Expected end pane active after enabling end time, got: %s", activeContent)
 	}
 }
 
@@ -151,6 +198,8 @@ func TestDateTimePickerRangeModeShowsEndDateInDisplay(t *testing.T) {
 		chromedp.Sleep(200*time.Millisecond),
 		chromedp.Click(`.time-option`, chromedp.ByQuery),
 		chromedp.Sleep(200*time.Millisecond),
+		chromedp.Evaluate(`document.querySelector('.datetime-end-checkbox').click()`, nil),
+		chromedp.Sleep(400*time.Millisecond),
 		chromedp.Click(`.datetime-toggle-btn[data-mode="end"]`, chromedp.ByQuery),
 		chromedp.Sleep(500*time.Millisecond),
 		// Use JS click to bypass chromedp viewport visibility checks for end pane elements
@@ -195,6 +244,8 @@ func TestDateTimePickerSingleModeNoEndDateAfterRangeMode(t *testing.T) {
 		chromedp.Sleep(200*time.Millisecond),
 		chromedp.Click(`.time-option`, chromedp.ByQuery),
 		chromedp.Sleep(200*time.Millisecond),
+		chromedp.Evaluate(`document.querySelector('.datetime-end-checkbox').click()`, nil),
+		chromedp.Sleep(400*time.Millisecond),
 		chromedp.Click(`.datetime-toggle-btn[data-mode="end"]`, chromedp.ByQuery),
 		chromedp.Sleep(500*time.Millisecond),
 		// Use JS click to bypass chromedp viewport visibility checks for end pane elements
@@ -367,5 +418,172 @@ func TestDateTimePickerDeadlineAfterEventPickerUsedEndMode(t *testing.T) {
 	}
 	if activeContent != "start" {
 		t.Errorf("expected [data-content='start'] to be active after opening deadline picker, got %q", activeContent)
+	}
+}
+
+// TestDateTimePickerUncheckingEndClearsEndTime verifies that enabling end time,
+// saving (which writes end_time), then unchecking the "Add end time" checkbox
+// and saving again clears the end_time input. This satisfies the requirement
+// that an end datetime can be removed after being set.
+func TestDateTimePickerUncheckingEndClearsEndTime(t *testing.T) {
+	requireServer(t)
+	ctx, cancel := chromedp.NewContext(context.Background())
+	defer cancel()
+	ctx, cancel = context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+
+	var endValueAfterSet, endValueAfterClear string
+	err := chromedp.Run(ctx,
+		chromedp.Navigate("http://localhost:8080/static/datetime_picker_test.html"),
+		chromedp.WaitVisible(`#event_datetime_trigger`, chromedp.ByID),
+		chromedp.Click(`#event_datetime_trigger`, chromedp.ByID),
+		chromedp.WaitVisible(`.datetime-picker-panel.open`, chromedp.ByQuery),
+		chromedp.Sleep(400*time.Millisecond),
+
+		// Pick start date + time
+		chromedp.Click(`.calendar-day:not(.other-month):not(.disabled)`, chromedp.ByQuery),
+		chromedp.Sleep(200*time.Millisecond),
+		chromedp.Click(`.time-option`, chromedp.ByQuery),
+		chromedp.Sleep(200*time.Millisecond),
+
+		// Enable end and pick an end date (second available day) + time
+		chromedp.Evaluate(`document.querySelector('.datetime-end-checkbox').click()`, nil),
+		chromedp.Sleep(400*time.Millisecond),
+		chromedp.Evaluate(`(function(){var d=document.querySelectorAll('.datetime-picker-content[data-content="end"] .calendar-day:not(.other-month):not(.disabled)');if(d.length>1){d[1].click();return true;}return false;})()`, nil),
+		chromedp.Sleep(300*time.Millisecond),
+		chromedp.Evaluate(`(function(){var t=document.querySelector('.datetime-picker-content[data-content="end"] .time-option:not(.disabled)');if(t){t.click();return true;}return false;})()`, nil),
+		chromedp.Sleep(200*time.Millisecond),
+		chromedp.Click(`.datetime-picker-save`, chromedp.ByQuery),
+		chromedp.Sleep(400*time.Millisecond),
+		chromedp.Value(`#end_time`, &endValueAfterSet, chromedp.ByID),
+
+		// Reopen, uncheck end, save — end_time must be cleared
+		chromedp.Click(`#event_datetime_trigger`, chromedp.ByID),
+		chromedp.WaitVisible(`.datetime-picker-panel.open`, chromedp.ByQuery),
+		chromedp.Sleep(400*time.Millisecond),
+		chromedp.Evaluate(`document.querySelector('.datetime-end-checkbox').click()`, nil),
+		chromedp.Sleep(300*time.Millisecond),
+		chromedp.Click(`.datetime-picker-save`, chromedp.ByQuery),
+		chromedp.Sleep(400*time.Millisecond),
+		chromedp.Value(`#end_time`, &endValueAfterClear, chromedp.ByID),
+	)
+	if err != nil {
+		t.Fatalf("Failed to run test: %v", err)
+	}
+	if endValueAfterSet == "" {
+		t.Error("end_time should be populated after enabling end and saving")
+	}
+	if endValueAfterClear != "" {
+		t.Errorf("end_time should be cleared after unchecking end and saving, got: %s", endValueAfterClear)
+	}
+}
+
+// TestDateTimePickerEndCalendarDisablesBeforeStart verifies that once a start
+// date is chosen and end time enabled, days strictly before the start date are
+// rendered as disabled in the end pane (cannot select end before start).
+func TestDateTimePickerEndCalendarDisablesBeforeStart(t *testing.T) {
+	requireServer(t)
+	ctx, cancel := chromedp.NewContext(context.Background())
+	defer cancel()
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// JS that picks a start day, enables end, then reports whether any
+	// non-other-month day earlier than the selected start day is clickable
+	// (i.e. lacks the 'disabled' class). The picker is correct when the
+	// returned count of such clickably-invalid days is 0.
+	var invalidClickableDays int64
+	err := chromedp.Run(ctx,
+		chromedp.Navigate("http://localhost:8080/static/datetime_picker_test.html"),
+		chromedp.WaitVisible(`#event_datetime_trigger`, chromedp.ByID),
+		chromedp.Click(`#event_datetime_trigger`, chromedp.ByID),
+		chromedp.WaitVisible(`.datetime-picker-panel.open`, chromedp.ByQuery),
+		chromedp.Sleep(400*time.Millisecond),
+
+		// Pick a start day that is NOT the first of the month, so earlier
+		// same-month days exist to test against.
+		chromedp.Evaluate(`(function(){
+			var days = document.querySelectorAll('.datetime-picker-content[data-content="start"] .calendar-day:not(.other-month):not(.disabled)');
+			for (var i = days.length - 1; i >= 0; i--) {
+				var n = parseInt(days[i].textContent, 10);
+				if (n > 2) { days[i].click(); return true; }
+			}
+			return false;
+		})()`, nil),
+		chromedp.Sleep(300*time.Millisecond),
+		chromedp.Click(`.time-option`, chromedp.ByQuery),
+		chromedp.Sleep(200*time.Millisecond),
+
+		chromedp.Evaluate(`document.querySelector('.datetime-end-checkbox').click()`, nil),
+		chromedp.Sleep(400*time.Millisecond),
+
+		chromedp.Evaluate(`(function(){
+			var endDays = document.querySelectorAll('.datetime-picker-content[data-content="end"] .calendar-day:not(.other-month)');
+			var startText = (document.querySelector('.datetime-picker-content[data-content="start"] .calendar-day.selected')||{}).textContent;
+			var startNum = parseInt(startText, 10);
+			var bad = 0;
+			endDays.forEach(function(d){
+				var n = parseInt(d.textContent, 10);
+				if (!isNaN(startNum) && !isNaN(n) && n < startNum && !d.classList.contains('disabled')) { bad++; }
+			});
+			return bad;
+		})()`, &invalidClickableDays),
+	)
+	if err != nil {
+		t.Fatalf("Failed to run test: %v", err)
+	}
+	if invalidClickableDays != 0 {
+		t.Errorf("Expected no clickable end days before start date, got %d", invalidClickableDays)
+	}
+}
+
+// TestDateTimePickerMovingStartAfterEndClearsEnd verifies that when an end time
+// is set, moving the start date to a later day than the end (which would make
+// end < start) clears the end selection on save, rather than persisting an
+// invalid range that errors on submit.
+func TestDateTimePickerMovingStartAfterEndClearsEnd(t *testing.T) {
+	requireServer(t)
+	ctx, cancel := chromedp.NewContext(context.Background())
+	defer cancel()
+	ctx, cancel = context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+
+	var endValueAfterMove string
+	err := chromedp.Run(ctx,
+		chromedp.Navigate("http://localhost:8080/static/datetime_picker_test.html"),
+		chromedp.WaitVisible(`#event_datetime_trigger`, chromedp.ByID),
+		chromedp.Click(`#event_datetime_trigger`, chromedp.ByID),
+		chromedp.WaitVisible(`.datetime-picker-panel.open`, chromedp.ByQuery),
+		chromedp.Sleep(400*time.Millisecond),
+
+		// Pick an early start day
+		chromedp.Evaluate(`(function(){var d=document.querySelector('.datetime-picker-content[data-content="start"] .calendar-day:not(.other-month):not(.disabled)');if(d){d.click();return true;}return false;})()`, nil),
+		chromedp.Sleep(300*time.Millisecond),
+		chromedp.Click(`.time-option`, chromedp.ByQuery),
+		chromedp.Sleep(200*time.Millisecond),
+
+		// Enable end, pick the very next day as end
+		chromedp.Evaluate(`document.querySelector('.datetime-end-checkbox').click()`, nil),
+		chromedp.Sleep(400*time.Millisecond),
+		chromedp.Evaluate(`(function(){var d=document.querySelectorAll('.datetime-picker-content[data-content="end"] .calendar-day:not(.other-month):not(.disabled)');if(d.length>1){d[1].click();return true;}return false;})()`, nil),
+		chromedp.Sleep(300*time.Millisecond),
+		chromedp.Evaluate(`(function(){var t=document.querySelector('.datetime-picker-content[data-content="end"] .time-option:not(.disabled)');if(t){t.click();return true;}return false;})()`, nil),
+		chromedp.Sleep(200*time.Millisecond),
+
+		// Switch back to start and pick a day far in the future (last available)
+		chromedp.Click(`.datetime-toggle-btn[data-mode="start"]`, chromedp.ByQuery),
+		chromedp.Sleep(300*time.Millisecond),
+		chromedp.Evaluate(`(function(){var d=document.querySelectorAll('.datetime-picker-content[data-content="start"] .calendar-day:not(.other-month):not(.disabled)');if(d.length){d[d.length-1].click();return true;}return false;})()`, nil),
+		chromedp.Sleep(300*time.Millisecond),
+
+		chromedp.Click(`.datetime-picker-save`, chromedp.ByQuery),
+		chromedp.Sleep(400*time.Millisecond),
+		chromedp.Value(`#end_time`, &endValueAfterMove, chromedp.ByID),
+	)
+	if err != nil {
+		t.Fatalf("Failed to run test: %v", err)
+	}
+	if endValueAfterMove != "" {
+		t.Errorf("end_time should be cleared after moving start past end, got: %s", endValueAfterMove)
 	}
 }

--- a/static/js/datetime_picker_test.js
+++ b/static/js/datetime_picker_test.js
@@ -50,6 +50,10 @@ describe('DateTimePicker Toggle Group Visibility', () => {
                     <button class="datetime-picker-close">×</button>
                 </div>
                 <div class="datetime-picker-body">
+                    <label class="datetime-end-toggle">
+                        <input type="checkbox" class="datetime-end-checkbox">
+                        <span class="datetime-end-toggle-label">Add end time</span>
+                    </label>
                     <div class="datetime-toggle-group">
                         <button type="button" class="datetime-toggle-btn active" data-mode="start">
                             <span class="datetime-toggle-label">Start Time</span>
@@ -156,16 +160,35 @@ describe('DateTimePicker Toggle Group Visibility', () => {
         }, 100);
     });
 
-    test('toggle group should be visible for datetime-range mode', (done) => {
+    test('toggle group should be hidden by default for datetime-range mode (end disabled)', (done) => {
         const eventTrigger = document.getElementById('event_datetime_trigger');
-        
+
         setTimeout(() => {
             eventTrigger.click();
-            
+
             setTimeout(() => {
                 expect(panel.classList.contains('open')).toBe(true);
-                expect(toggleGroup.style.display).toBe('flex');
+                expect(toggleGroup.style.display).toBe('none');
                 done();
+            }, 100);
+        }, 100);
+    });
+
+    test('enabling end time shows the toggle group for datetime-range mode', (done) => {
+        const eventTrigger = document.getElementById('event_datetime_trigger');
+        const endCheckbox = document.querySelector('.datetime-end-checkbox');
+
+        setTimeout(() => {
+            eventTrigger.click();
+
+            setTimeout(() => {
+                expect(toggleGroup.style.display).toBe('none');
+                endCheckbox.click();
+
+                setTimeout(() => {
+                    expect(toggleGroup.style.display).toBe('flex');
+                    done();
+                }, 100);
             }, 100);
         }, 100);
     });
@@ -174,18 +197,19 @@ describe('DateTimePicker Toggle Group Visibility', () => {
         const eventTrigger = document.getElementById('event_datetime_trigger');
         const rsvpTrigger = document.getElementById('rsvp_deadline_trigger');
         const closeBtn = document.querySelector('.datetime-picker-close');
-        
+
         setTimeout(() => {
             eventTrigger.click();
-            
+
             setTimeout(() => {
-                expect(toggleGroup.style.display).toBe('flex');
-                
+                // Range mode hides the toggle group until end time is enabled.
+                expect(toggleGroup.style.display).toBe('none');
+
                 closeBtn.click();
-                
+
                 setTimeout(() => {
                     rsvpTrigger.click();
-                    
+
                     setTimeout(() => {
                         expect(panel.classList.contains('open')).toBe(true);
                         expect(toggleGroup.style.display).toBe('none');
@@ -288,6 +312,7 @@ describe('DateTimePicker Toggle Group Visibility', () => {
                             startTimeOptions[0].click();
                             
                             setTimeout(() => {
+                                document.querySelector('.datetime-end-checkbox').click();
                                 const endToggleBtn = panel.querySelector('.datetime-toggle-btn[data-mode="end"]');
                                 endToggleBtn.click();
                                 
@@ -352,6 +377,7 @@ describe('DateTimePicker Toggle Group Visibility', () => {
                             startTimeOptions[0].click();
                             
                             setTimeout(() => {
+                                document.querySelector('.datetime-end-checkbox').click();
                                 const endToggleBtn = panel.querySelector('.datetime-toggle-btn[data-mode="end"]');
                                 endToggleBtn.click();
                                 
@@ -470,6 +496,10 @@ describe('DateTimePicker active-instance isolation', () => {
                     <button class="datetime-picker-close">×</button>
                 </div>
                 <div class="datetime-picker-body">
+                    <label class="datetime-end-toggle">
+                        <input type="checkbox" class="datetime-end-checkbox">
+                        <span class="datetime-end-toggle-label">Add end time</span>
+                    </label>
                     <div class="datetime-toggle-group">
                         <button type="button" class="datetime-toggle-btn active" data-mode="start">
                             <span class="datetime-toggle-label">Start Time</span>

--- a/templates/web/partials/datetime_picker_panel.html
+++ b/templates/web/partials/datetime_picker_panel.html
@@ -6,6 +6,10 @@
         <button class="datetime-picker-close" aria-label="Close date picker">×</button>
     </div>
     <div class="datetime-picker-body">
+        <label class="datetime-end-toggle">
+            <input type="checkbox" class="datetime-end-checkbox">
+            <span class="datetime-end-toggle-label">Add end time</span>
+        </label>
         <div class="datetime-toggle-group">
             <button type="button" class="datetime-toggle-btn active" data-mode="start">
                 <span class="datetime-toggle-label">Start Time</span>


### PR DESCRIPTION
## Problem

The date/time picker when creating or updating an event didn\'t work properly:
- By default it showed **both** a start and end datetime and pre-filled a default end, but `EndTime` is an optional field.
- There was no way to clear an end datetime once set.
- If you moved the start date after an existing end date, the picker allowed it and the form errored on submit.

## Changes

**Start-only by default**
- `date_defaults.js` no longer pre-fills `end_time`; only `start_time` gets a default (the existing value still loads when editing an event that has an end time).

**Opt-in end datetime via checkbox**
- Added an **"Add end time"** checkbox to the shared picker panel (`datetime_picker_panel.html`, mirrored in the test fixture).
- `showEndTime` is now a dynamic per-instance property (default off) driven by the checkbox through a new `toggleEndTime()` method. The Start/End tabs only appear once end is enabled. Hidden for `datetime-single`/`date-only` pickers (e.g. RSVP deadline).

**Clear the end datetime**
- Unchecking the box clears the end selection, and `saveDateTime()` writes an empty `end_time`. The web handler already maps an empty `end_time` to `EndTime = nil` (`events_web.go:344`), so the end is removed on submit.

**Prevent end before start (three layers in the picker)**
- End calendar disables days before the start date (`_createDayElement`).
- End time list disables options `<=` the start time when end is the same day (`renderTimePicker` + `_endSameDayMinDateTime`).
- If moving the start date/time invalidates the existing end, the end selection is auto-cleared (`_clearEndIfInvalid`) instead of being allowed through and erroring on submit.

## Backend
No backend change needed — `validateEndTime` (`internal/events/validator.go:230`) and the SQLite `CHECK` constraint already enforced `end > start`. The fix is purely picker UX so users can\'t construct a range the server would reject.

## Tests
- Updated the 3 existing chromedp tests whose assertions encoded the old "end always visible" behavior, and added a checkbox-enable step before clicking the End tab.
- Added 4 new chromedp tests: end disabled by default, enabling end shows the toggle group, unchecking end clears `end_time`, end calendar disables pre-start days, and moving start past end clears end.
- Updated the Jest-style fixtures/assertions to match (added the checkbox to both fixtures, flipped the range-mode visibility expectations, and enable end before selecting it).

## Verification
- `go build ./...` clean
- `go vet ./static/js/ ./templates/... ./internal/events/... ./internal/handlers/...` clean
- `go test ./internal/events/...`, `./internal/handlers/...`, `./templates/...` pass
- The chromedp JS tests skip in this sandbox (no Chrome at localhost:8080) but compile and run in the dev environment.

## Scope
Only the 7 files I changed are in this PR. The pre-existing `.github/workflows/*.yml` modifications in the working tree are **not** included.