### PR TITLE
chore(ai): onboard to lenaxia/ai-workflows reusable workflows

### DIFF
--- a/.github/workflows/ai-comment.yml
+++ b/.github/workflows/ai-comment.yml
@@ -1,3 +1,18 @@
+# AI Commands — caller for lenaxia/ai-workflows.
+#
+# Delegates the slash-command AI flow (/ai, /fix, /implement, /review, /test,
+# /security, /analyze, /explain, /triage, /design, /merge, /help) to the central
+# reusable workflow, which owns prompt assembly (via route-command.sh), the
+# opencode run, and the once-per-thread command footer.
+#
+# The command-token + author_association filter MUST live here (the caller) — a
+# called workflow's job-level `if:` against github.event.comment.* is not
+# reliably evaluated for issue_comment / pull_request_review_comment events.
+#
+# Requires the repo variable AI_WORKFLOWS_PIN (tag or SHA of lenaxia/ai-workflows)
+# and the OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable,
+# which are inherited by the reusable workflow.
+
 name: AI Commands
 
 on:
@@ -36,73 +51,8 @@ jobs:
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR')
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-
-      - name: Build prompt
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          PR_URL: ${{ github.event.issue.pull_request.url }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-          # shellcheck source=.github/scripts/route-command.sh
-          source .github/scripts/route-command.sh
-          OUT_FILE=/tmp/opencode_prompt.txt route_command
-
-          {
-            echo "OPENCODE_PROMPT<<__PROMPT_EOF__"
-            cat "$OUT_FILE"
-            echo "__PROMPT_EOF__"
-          } >> "$GITHUB_ENV"
-
-      - name: Run OpenCode
-        uses: anomalyco/opencode/github@0cf0294787322664c6d668fa5ab0a9ce26796f78 # github-v1.2.9
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          model: openai-compatible/default
-          use_github_token: "true"
-          share: "false"
-          mentions: /ai
-          prompt: ${{ env.OPENCODE_PROMPT }}
-
-      - name: Post AI command reference (once per thread)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-          MARKER: '<!-- ai-commands-footer -->'
-        run: |
-          set -euo pipefail
-          if [ -z "${ISSUE_NUMBER:-}" ]; then
-            echo "No issue/PR number resolved; skipping command-reference comment."
-            exit 0
-          fi
-          if gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
-               --paginate -q '.[].body' | grep -qE "^${MARKER}"; then
-            echo "Command reference already present in thread #${ISSUE_NUMBER}; skipping."
-            exit 0
-          fi
-          if [ ! -f .github/prompts/commands-footer.md ]; then
-            echo "commands-footer.md missing on this ref (older branch); skipping."
-            exit 0
-          fi
-          {
-            printf '%s\n\n' "$MARKER"
-            cat .github/prompts/commands-footer.md
-          } > /tmp/commands-footer-comment.md
-          gh issue comment "$ISSUE_NUMBER" --body-file /tmp/commands-footer-comment.md
-          echo "Posted AI command reference to thread #${ISSUE_NUMBER}."
+    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@${{ vars.AI_WORKFLOWS_PIN }}
+    secrets: inherit
+    with:
+      version: ${{ vars.AI_WORKFLOWS_PIN }}
+      project_name: TinyRSVP

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -1,3 +1,12 @@
+# Issue Opened — caller for lenaxia/ai-workflows.
+#
+# Delegates the issue-responder AI flow to the central reusable workflow, which
+# owns prompt assembly, the opencode run, and the once-per-thread command footer.
+#
+# Requires the repo variable AI_WORKFLOWS_PIN (tag or SHA of lenaxia/ai-workflows)
+# and the OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable,
+# which are inherited by the reusable workflow.
+
 name: Issue Opened
 
 on:
@@ -6,65 +15,8 @@ on:
 
 jobs:
   respond:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Build prompt
-        run: |
-          set -euo pipefail
-          {
-            echo "OPENCODE_PROMPT<<__PROMPT_EOF__"
-            cat .github/prompts/context.md
-            printf '\n\n---\n\n'
-            cat .github/prompts/core-rules.md
-            printf '\n\n---\n\n'
-            cat .github/prompts/issue-responder.md
-            printf '\n\nA new GitHub issue has been opened. Analyze it and take the appropriate action.\n'
-            echo "__PROMPT_EOF__"
-          } >> "$GITHUB_ENV"
-
-      - name: Run OpenCode
-        uses: anomalyco/opencode/github@0cf0294787322664c6d668fa5ab0a9ce26796f78 # github-v1.2.9
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          model: openai-compatible/default
-          use_github_token: "true"
-          share: "false"
-          prompt: ${{ env.OPENCODE_PROMPT }}
-
-      - name: Post AI command reference (once per thread)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          MARKER: '<!-- ai-commands-footer -->'
-        run: |
-          set -euo pipefail
-          if [ -z "${ISSUE_NUMBER:-}" ]; then
-            echo "No issue number resolved; skipping command-reference comment."
-            exit 0
-          fi
-          if gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
-               --paginate -q '.[].body' | grep -qE "^${MARKER}"; then
-            echo "Command reference already present in thread #${ISSUE_NUMBER}; skipping."
-            exit 0
-          fi
-          {
-            printf '%s\n\n' "$MARKER"
-            cat .github/prompts/commands-footer.md
-          } > /tmp/commands-footer-comment.md
-          gh issue comment "$ISSUE_NUMBER" --body-file /tmp/commands-footer-comment.md
-          echo "Posted AI command reference to thread #${ISSUE_NUMBER}."
+    uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@${{ vars.AI_WORKFLOWS_PIN }}
+    secrets: inherit
+    with:
+      version: ${{ vars.AI_WORKFLOWS_PIN }}
+      project_name: TinyRSVP

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,3 +1,14 @@
+# PR Review — caller for lenaxia/ai-workflows.
+#
+# Delegates the AI PR-review flow to the central reusable workflow, which owns
+# prompt assembly, the opencode run, and the once-per-thread command footer.
+# The reusable workflow appends the formal-blocking-review directive (submit via
+# `gh pr review` as APPROVE / REQUEST_CHANGES — never a plain comment).
+#
+# Requires the repo variable AI_WORKFLOWS_PIN (tag or SHA of lenaxia/ai-workflows)
+# and the OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable,
+# which are inherited by the reusable workflow.
+
 name: PR Review
 
 on:
@@ -7,65 +18,8 @@ on:
 jobs:
   review:
     if: github.event.pull_request.user.login != 'renovate[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-
-      - name: Build prompt
-        run: |
-          set -euo pipefail
-          {
-            echo "OPENCODE_PROMPT<<__PROMPT_EOF__"
-            cat .github/prompts/context.md
-            printf '\n\n---\n\n'
-            cat .github/prompts/core-rules.md
-            printf '\n\n---\n\n'
-            cat .github/prompts/pr-review.md
-            printf '\n\nA new pull request has been opened. Perform a thorough review and post your findings as a PR review comment.\n'
-            echo "__PROMPT_EOF__"
-          } >> "$GITHUB_ENV"
-
-      - name: Run OpenCode
-        uses: anomalyco/opencode/github@0cf0294787322664c6d668fa5ab0a9ce26796f78 # github-v1.2.9
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          model: openai-compatible/default
-          use_github_token: "true"
-          share: "false"
-          prompt: ${{ env.OPENCODE_PROMPT }}
-
-      - name: Post AI command reference (once per thread)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.pull_request.number }}
-          MARKER: '<!-- ai-commands-footer -->'
-        run: |
-          set -euo pipefail
-          if [ -z "${ISSUE_NUMBER:-}" ]; then
-            echo "No PR number resolved; skipping command-reference comment."
-            exit 0
-          fi
-          if gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
-               --paginate -q '.[].body' | grep -qE "^${MARKER}"; then
-            echo "Command reference already present in thread #${ISSUE_NUMBER}; skipping."
-            exit 0
-          fi
-          {
-            printf '%s\n\n' "$MARKER"
-            cat .github/prompts/commands-footer.md
-          } > /tmp/commands-footer-comment.md
-          gh issue comment "$ISSUE_NUMBER" --body-file /tmp/commands-footer-comment.md
-          echo "Posted AI command reference to thread #${ISSUE_NUMBER}."
+    uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@${{ vars.AI_WORKFLOWS_PIN }}
+    secrets: inherit
+    with:
+      version: ${{ vars.AI_WORKFLOWS_PIN }}
+      project_name: TinyRSVP


### PR DESCRIPTION
## What

Converts the three AI workflows from inline `anomalyco/opencode/github` runs to thin callers over `lenaxia/ai-workflows`:

```yaml
jobs:
  respond:
    if: <command-token + author_association filter>   # stays in caller
    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@${{ vars.AI_WORKFLOWS_PIN }}
    secrets: inherit
    with: { version, project_name: TinyRSVP }
```

Prompt assembly (`route-command.sh`), the opencode run, the **formal-blocking-review** directive (APPROVE / REQUEST\_CHANGES via `gh pr review`, never COMMENT), and the once-per-thread footer are now owned centrally and sourced from the pinned `ai-workflows` ref.

## Prompts left untouched

TinyRSVP's prompts are RSVP-specific (Chi router, SQLite/PostgreSQL, OIDC + Forward Auth, token-based guest access, email queue, XSS/CSRF/SQL-injection checks) and are **not** touched. `consumers/tinyrsvp.yaml` now forks all 15 prompts (ai-workflows#2), so a `propagate` run will never clobber them with the gokore-derived templates.

## Why keep the filter in the caller

A called workflow's job-level `if:` against `github.event.comment.*` is not reliably evaluated for `issue_comment` / `pull_request_review_comment` events, so the command-token + `author_association` filter must stay in the caller. Same for the `renovate[bot]` skip on `pr-review`.

## Companion: self-hosted-runner git-identity fix

This repo's inline workflows never had a "Configure git identity" step. The org's self-hosted runners need one before the opencode step can `git commit`. I'm opening ai-workflows#3 to add it to the reusable workflows (where it now belongs) and cut `v0.1.2`; this repo's `AI_WORKFLOWS_PIN` should bump to `v0.1.2` to pick it up.

## Prerequisites

- `AI_WORKFLOWS_PIN` repo variable = `v0.1.1` (set) → bump to `v0.1.2` after ai-workflows#3 merges
- `OPENAI_API_KEY` / `OPENAI_API_BASE` secrets + `OPENAI_MODEL` var (exist, via `secrets: inherit`)

## Verification

- All 3 caller workflows parse (YAML).
- ai-workflows router (87) + renderer (7) tests pass.