### PR TITLE
fix(ci): hardcode ai-workflows pin — vars context not allowed in uses:

### DIFF
--- a/.github/workflows/ai-comment.yml
+++ b/.github/workflows/ai-comment.yml
@@ -9,9 +9,8 @@
 # called workflow's job-level `if:` against github.event.comment.* is not
 # reliably evaluated for issue_comment / pull_request_review_comment events.
 #
-# Requires the repo variable AI_WORKFLOWS_PIN (tag or SHA of lenaxia/ai-workflows)
-# and the OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable,
-# which are inherited by the reusable workflow.
+# Pinned to ai-workflows v0.1.2 — bump by editing the tag below (or via propagate.yml).
+# Requires OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable (inherited).
 
 name: AI Commands
 
@@ -51,8 +50,8 @@ jobs:
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR')
-    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@${{ vars.AI_WORKFLOWS_PIN }}
+    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@v0.1.2
     secrets: inherit
     with:
-      version: ${{ vars.AI_WORKFLOWS_PIN }}
+      version: v0.1.2
       project_name: TinyRSVP

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -3,9 +3,8 @@
 # Delegates the issue-responder AI flow to the central reusable workflow, which
 # owns prompt assembly, the opencode run, and the once-per-thread command footer.
 #
-# Requires the repo variable AI_WORKFLOWS_PIN (tag or SHA of lenaxia/ai-workflows)
-# and the OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable,
-# which are inherited by the reusable workflow.
+# Pinned to ai-workflows v0.1.2 — bump by editing the tag below (or via propagate.yml).
+# Requires OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable (inherited).
 
 name: Issue Opened
 
@@ -15,8 +14,8 @@ on:
 
 jobs:
   respond:
-    uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@${{ vars.AI_WORKFLOWS_PIN }}
+    uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@v0.1.2
     secrets: inherit
     with:
-      version: ${{ vars.AI_WORKFLOWS_PIN }}
+      version: v0.1.2
       project_name: TinyRSVP

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,9 +5,8 @@
 # The reusable workflow appends the formal-blocking-review directive (submit via
 # `gh pr review` as APPROVE / REQUEST_CHANGES — never a plain comment).
 #
-# Requires the repo variable AI_WORKFLOWS_PIN (tag or SHA of lenaxia/ai-workflows)
-# and the OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable,
-# which are inherited by the reusable workflow.
+# Pinned to ai-workflows v0.1.2 — bump by editing the tag below (or via propagate.yml).
+# Requires OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable (inherited).
 
 name: PR Review
 
@@ -18,8 +17,8 @@ on:
 jobs:
   review:
     if: github.event.pull_request.user.login != 'renovate[bot]'
-    uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@${{ vars.AI_WORKFLOWS_PIN }}
+    uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@v0.1.2
     secrets: inherit
     with:
-      version: ${{ vars.AI_WORKFLOWS_PIN }}
+      version: v0.1.2
       project_name: TinyRSVP


### PR DESCRIPTION
## Problem

The `uses: ...@${{ vars.AI_WORKFLOWS_PIN }}` pattern from #55 causes every workflow file to fail GitHub validation on push:

> `context "vars" is not allowed here. no context is available here.`

GitHub's [context-availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) has **no entry for `jobs.<job_id>.uses`** — no contexts (including `vars`) are permitted in the reusable-workflow ref. It must be a literal string.

## Fix

Hardcode `@v0.1.2` in both `uses:` and `version:`:
```yaml
uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@v0.1.2
with:
  version: v0.1.2
```

Both are hardcoded to the same tag so the reusable workflow's second checkout (for `route-command.sh`, `post-footer.sh`) always matches the workflow-definition ref.

## Verification

actionlint passes clean on all 3 workflows (no errors).