### PR TITLE
fix(ci): add explicit permissions block to AI workflow callers

### DIFF
--- a/.github/workflows/ai-comment.yml
+++ b/.github/workflows/ai-comment.yml
@@ -20,6 +20,12 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions:
+  id-token: write
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   respond:
     if: |

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -12,6 +12,12 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   respond:
     uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@v0.1.2

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -14,6 +14,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   review:
     if: github.event.pull_request.user.login != 'renovate[bot]'


### PR DESCRIPTION
## Problem

AI workflows fail with `startup_failure` (zero jobs) on every trigger. Root cause: the caller workflows lack a `permissions:` block, so they use the repo's default workflow permissions. A reusable workflow's permissions **cannot exceed the caller's** — if the default is read-only, GitHub rejects the job at startup.

## Fix

Add workflow-level `permissions:` matching each reusable workflow's needs (same as the old inline workflows had at the job level).