### PR TITLE
fix: protect /metrics endpoint and role-gate admin nav

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,22 @@ STORAGE_LOCAL_PATH=/data/uploads
 
 
 # ------------------------------------------------------------
+# MONITORING  (optional — /metrics Prometheus endpoint)
+# ------------------------------------------------------------
+# The raw Prometheus scrape endpoint (/metrics) is NOT behind login auth
+# because Prometheus cannot authenticate with a browser session. Instead it is
+# gated by an IP allowlist. The human-readable dashboard lives at /admin/metrics
+# behind admin auth and is unaffected.
+#
+# When METRICS_TRUSTED_IPS is unset, only loopback (127.0.0.0/8, ::1) can scrape
+# /metrics — safe for same-host Prometheus. To allow a scraper on another host
+# or Docker container, list its IP or CIDR here.
+# Individual IPs:  10.0.0.5
+# CIDR range:      172.19.0.0/16
+# METRICS_TRUSTED_IPS=
+
+
+# ------------------------------------------------------------
 # LOGGING  (optional)
 # ------------------------------------------------------------
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -276,6 +276,7 @@ func main() {
 
 	metricsCollector := middleware.NewPrometheusMetricsWithRegistry(prometheus.DefaultRegisterer)
 	metricsHandler := middleware.MetricsHandler(metricsCollector)
+	metricsHandler = middleware.MetricsIPAllowlist(cfg.Metrics.TrustedIPs)(metricsHandler)
 	logger.Info("Prometheus metrics initialized")
 
 	userHandler := handlers.NewUserHandler(userService, authChecker)
@@ -722,7 +723,7 @@ func main() {
 	logger.Info("Router initialized with all handlers")
 	logger.Info("Registered auth endpoints", "paths", "/login, /auth/callback, /logout")
 	logger.Info("Registered health endpoints", "paths", "/health, /ready")
-	logger.Info("Registered metrics endpoint", "path", "/metrics", "method", "GET", "protection", "none")
+	logger.Info("Registered metrics endpoint", "path", "/metrics", "method", "GET", "protection", "ip-allowlist", "default", "loopback-only", "trusted_ips", cfg.Metrics.TrustedIPs)
 	logger.Info("Registered dashboard endpoint", "path", "/", "method", "GET", "protection", "authenticated")
 	logger.Info("Registered event management endpoints", "path", "/api/events", "protection", "authenticated")
 	logger.Info("Registered event web UI endpoints", "prefix", "/events", "protection", "authenticated")

--- a/docs/01_WORKLOG/0178_2026-08-01_metrics_protection_admin_nav.md
+++ b/docs/01_WORKLOG/0178_2026-08-01_metrics_protection_admin_nav.md
@@ -1,0 +1,63 @@
+# Worklog: Protect /metrics Endpoint and Role-Gate Admin Nav
+
+**Date:** 2026-08-01  
+**PR:** [#61](https://github.com/lenaxia/TinyRSVP/pull/61)  
+**Issues:** #7, #13
+
+## Summary
+
+Two security/UX fixes: gated the raw Prometheus `/metrics` endpoint behind an IP allowlist (loopback default + configurable), and role-gated the Admin navigation link so non-admins no longer see it (and hit a 403).
+
+## Work Completed
+
+- [x] **#7 — `/metrics` IP allowlist**: New `MetricsIPAllowlist` middleware (`internal/middleware/metrics_allowlist.go`) permits loopback (`127.0.0.0/8`, `::1`) by default and any IPs/CIDRs in the new `METRICS_TRUSTED_IPS` env var. Client IP read via `GetRealIP` so it works behind a proxy. Wired in `cmd/server/main.go`; updated the startup log line (`protection: ip-allowlist`).
+- [x] Extracted shared IP/CIDR parsing + validation into `config/ip_list.go`, reused by forward-auth (removed duplicated validation in `forward_auth.go`).
+- [x] Added `MetricsConfig{ TrustedIPs }` to the Config struct, loaded via `loadFromEnv`, validated via `validateMetrics`.
+- [x] Documented `METRICS_TRUSTED_IPS` in `.env.example`.
+- [x] **#13 — admin nav role-gating**: Added `IsAdmin bool` to each staff page-data struct + the invites data map; populated via shared `isAdminRequest(r)` helper (`internal/handlers/nav.go`) reading role from the auth context; gated the link with `{{if .IsAdmin}}` in `navigation.html`.
+
+## Decisions Made
+
+### Decision 1: IP allowlist vs RequireAuth for /metrics
+**Context:** Issue #7 suggested "RequireAuth or IP allowlist".  
+**Decision:** IP allowlist. Prometheus scrapers cannot authenticate via browser session cookies, so RequireAuth would break scraping. The human-readable `/admin/metrics` dashboard (behind admin auth) is unchanged and remains for operators.
+
+### Decision 2: loopback default vs deny-all default
+**Context:** When `METRICS_TRUSTED_IPS` is unset, what should the default be?  
+**Decision:** Loopback-only. This keeps same-host Prometheus scraping working out of the box (the common homelab case) while closing public exposure. Operators scraping from another host/container set `METRICS_TRUSTED_IPS` to the scraper IP or Docker subnet.
+
+### Decision 3: per-struct IsAdmin field vs embedded NavData
+**Context:** ~12 page-data structs render the nav.  
+**Decision:** Add `IsAdmin bool` directly to each struct (flat field) + a shared `isAdminRequest(r)` helper, rather than introducing an embedded `NavData` type. Lower risk (no field-removal refactor, no reliance on field promotion), matches the existing flat `ActivePage` style.
+
+## Files Changed
+
+- `internal/middleware/metrics_allowlist.go` — new IP allowlist middleware
+- `internal/config/ip_list.go` — shared IP/CIDR parse + validate helpers
+- `internal/config/config.go` — `MetricsConfig` + load/validate wiring
+- `internal/config/forward_auth.go` — refactored to use shared helpers
+- `cmd/server/main.go` — wrap metrics handler with allowlist; update log
+- `.env.example` — documented `METRICS_TRUSTED_IPS`
+- `internal/handlers/nav.go` — `isAdminRequest(r)` helper
+- `internal/handlers/{admin,dashboard,events_web,invites_web,metrics,settings,rsvp_summary,template_editor}.go` — `IsAdmin` field + population
+- `templates/web/partials/navigation.html` — `{{if .IsAdmin}}` around Admin link
+- `templates/web/rsvp_summary_test.go` — add `IsAdmin` to local test struct
+
+## Tests
+
+- [x] `internal/middleware/metrics_allowlist_test.go` — 11 cases (loopback default allow/deny, explicit IP/CIDR, X-Forwarded-For, malformed addr)
+- [x] `internal/config/metrics_test.go` — env parsing + validation
+- [x] `templates/web/partials/navigation_test.go` — admin link shown/hidden; Dashboard/Events always present
+- [x] Updated `forward_auth_test.go` for improved error messages
+- [x] All 39 non-browser packages pass; browser tests unaffected (skip in this sandbox)
+
+## Notes
+
+- The `review` GitHub check shows FAILURE, but the formal review is **APPROVE**; the check failure is the bot failing to git-push (403 permission error), not a code rejection.
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** All non-browser tests pass  
+**Confidence:** HIGH  
+**Production Ready:** Yes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Storage     StorageConfig
 	Security    SecurityConfig
 	Token       TokenConfig
+	Metrics     MetricsConfig
 }
 
 type ServerConfig struct {
@@ -83,6 +84,16 @@ type SecurityConfig struct {
 type TokenConfig struct {
 	Secret         string
 	HashingEnabled bool
+}
+
+// MetricsConfig controls access to the raw Prometheus /metrics scrape
+// endpoint. The human-readable dashboard lives at /admin/metrics behind admin
+// auth; /metrics is consumed by scrapers that cannot authenticate via session
+// cookies, so it is gated by an IP allowlist instead.
+type MetricsConfig struct {
+	// TrustedIPs is a list of IPs or CIDR ranges permitted to scrape /metrics.
+	// When empty, only loopback (127.0.0.0/8, ::1) is permitted.
+	TrustedIPs []string
 }
 
 func Load() (*Config, error) {
@@ -169,6 +180,8 @@ func (c *Config) loadFromEnv() error {
 	if err := c.loadForwardAuthFromEnv(); err != nil {
 		return err
 	}
+
+	c.Metrics.TrustedIPs = parseIPListFromEnv("METRICS_TRUSTED_IPS")
 
 	c.Email.SMTPHost = getEnvString("SMTP_HOST", "")
 	if c.Email.SMTPHost == "" {
@@ -260,6 +273,10 @@ func (c *Config) Validate() error {
 
 	if err := c.validateAuthModes(); err != nil {
 		return fmt.Errorf("auth config: %w", err)
+	}
+
+	if err := c.validateMetrics(); err != nil {
+		return fmt.Errorf("metrics config: %w", err)
 	}
 
 	if err := c.validateEmail(); err != nil {

--- a/internal/config/forward_auth.go
+++ b/internal/config/forward_auth.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"fmt"
-	"net"
-	"strings"
 )
 
 func (c *Config) loadForwardAuthFromEnv() error {
@@ -16,14 +14,7 @@ func (c *Config) loadForwardAuthFromEnv() error {
 
 	c.ForwardAuth.UserHeader = getEnvString("FORWARD_AUTH_USER_HEADER", "")
 	c.ForwardAuth.EmailHeader = getEnvString("FORWARD_AUTH_EMAIL_HEADER", "")
-
-	trustedIPsStr := getEnvString("FORWARD_AUTH_TRUSTED_IPS", "")
-	if trustedIPsStr != "" {
-		c.ForwardAuth.TrustedIPs = strings.Split(trustedIPsStr, ",")
-		for i := range c.ForwardAuth.TrustedIPs {
-			c.ForwardAuth.TrustedIPs[i] = strings.TrimSpace(c.ForwardAuth.TrustedIPs[i])
-		}
-	}
+	c.ForwardAuth.TrustedIPs = parseIPListFromEnv("FORWARD_AUTH_TRUSTED_IPS")
 
 	return nil
 }
@@ -45,20 +36,13 @@ func (c *Config) validateForwardAuth() error {
 		return fmt.Errorf("at least one trusted IP is required when forward auth is enabled")
 	}
 
-	for _, entry := range c.ForwardAuth.TrustedIPs {
-		// Accept both individual IPs and CIDR ranges (e.g. 172.19.0.0/16).
-		if strings.Contains(entry, "/") {
-			if _, _, err := net.ParseCIDR(entry); err != nil {
-				return fmt.Errorf("invalid CIDR range: %s", entry)
-			}
-		} else {
-			if net.ParseIP(entry) == nil {
-				return fmt.Errorf("invalid IP address: %s", entry)
-			}
-		}
-	}
+	return validateIPList("forward auth", c.ForwardAuth.TrustedIPs)
+}
 
-	return nil
+// validateMetrics validates the METRICS_TRUSTED_IPS entries, if any. An empty
+// list is valid (defaults to loopback-only at the middleware layer).
+func (c *Config) validateMetrics() error {
+	return validateIPList("metrics", c.Metrics.TrustedIPs)
 }
 
 func (c *Config) validateAuthModes() error {
@@ -67,3 +51,4 @@ func (c *Config) validateAuthModes() error {
 	}
 	return nil
 }
+

--- a/internal/config/forward_auth_test.go
+++ b/internal/config/forward_auth_test.go
@@ -192,7 +192,7 @@ func TestForwardAuthConfig_Validate(t *testing.T) {
 				TrustedIPs:  []string{"not-an-ip"},
 			},
 			wantErr: true,
-			errMsg:  "invalid IP address",
+			errMsg:  "invalid forward auth IP address",
 		},
 		{
 			name: "valid IPv6",
@@ -243,7 +243,7 @@ func TestForwardAuthConfig_Validate(t *testing.T) {
 				TrustedIPs:  []string{"999.999.0.0/8"},
 			},
 			wantErr: true,
-			errMsg:  "invalid CIDR range",
+			errMsg:  "invalid forward auth CIDR range",
 		},
 	}
 

--- a/internal/config/ip_list.go
+++ b/internal/config/ip_list.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// parseIPListFromEnv reads a comma-separated list of IPs or CIDR ranges from
+// the named environment variable and trims whitespace from each entry.
+func parseIPListFromEnv(name string) []string {
+	raw := getEnvString(name, "")
+	if raw == "" {
+		return nil
+	}
+	entries := strings.Split(raw, ",")
+	for i := range entries {
+		entries[i] = strings.TrimSpace(entries[i])
+	}
+	return entries
+}
+
+// validateIPList validates that every entry is either a valid IP address or a
+// valid CIDR range. name labels the list for error messages.
+func validateIPList(name string, entries []string) error {
+	for _, entry := range entries {
+		if strings.Contains(entry, "/") {
+			if _, _, err := net.ParseCIDR(entry); err != nil {
+				return fmt.Errorf("invalid %s CIDR range: %s", name, entry)
+			}
+		} else {
+			if net.ParseIP(entry) == nil {
+				return fmt.Errorf("invalid %s IP address: %s", name, entry)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/config/metrics_test.go
+++ b/internal/config/metrics_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMetricsConfig_LoadFromEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		want    MetricsConfig
+	}{
+		{
+			name:    "unset defaults to empty (loopback-only at middleware)",
+			envVars: nil,
+			want:    MetricsConfig{TrustedIPs: nil},
+		},
+		{
+			name: "single IP",
+			envVars: map[string]string{
+				"METRICS_TRUSTED_IPS": "10.0.0.5",
+			},
+			want: MetricsConfig{TrustedIPs: []string{"10.0.0.5"}},
+		},
+		{
+			name: "multiple IPs and CIDRs with whitespace",
+			envVars: map[string]string{
+				"METRICS_TRUSTED_IPS": "10.0.0.5, 172.19.0.0/16 , 192.168.1.1",
+			},
+			want: MetricsConfig{TrustedIPs: []string{"10.0.0.5", "172.19.0.0/16", "192.168.1.1"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("METRICS_TRUSTED_IPS", "")
+			if tt.envVars == nil {
+				os.Unsetenv("METRICS_TRUSTED_IPS")
+			} else {
+				for k, v := range tt.envVars {
+					t.Setenv(k, v)
+				}
+			}
+			cfg := &Config{}
+			cfg.Metrics.TrustedIPs = parseIPListFromEnv("METRICS_TRUSTED_IPS")
+			if !equalIPLists(cfg.Metrics.TrustedIPs, tt.want.TrustedIPs) {
+				t.Errorf("TrustedIPs = %v, want %v", cfg.Metrics.TrustedIPs, tt.want.TrustedIPs)
+			}
+		})
+	}
+}
+
+func TestMetricsConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		ips     []string
+		wantErr bool
+		errMsg  string
+	}{
+		{"empty is valid (loopback default)", nil, false, ""},
+		{"valid IP", []string{"10.0.0.5"}, false, ""},
+		{"valid CIDR", []string{"172.19.0.0/16"}, false, ""},
+		{"valid mixed", []string{"10.0.0.5", "172.19.0.0/16"}, false, ""},
+		{"invalid IP", []string{"not-an-ip"}, true, "invalid metrics IP address"},
+		{"invalid CIDR", []string{"999.999.0.0/8"}, true, "invalid metrics CIDR range"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Metrics: MetricsConfig{TrustedIPs: tt.ips}}
+			err := cfg.validateMetrics()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateMetrics() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errMsg != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("validateMetrics() error = %v, want error containing %q", err, tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+func equalIPLists(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -37,6 +37,7 @@ type AdminDashboardHandler struct {
 
 type AdminDashboardPageData struct {
 	ActivePage string
+	IsAdmin    bool
 	User       *models.User
 	Stats      *AdminDashboardStats
 	EmailQueue *EmailQueueMetrics
@@ -89,6 +90,7 @@ func (h *AdminDashboardHandler) AdminDashboard(w http.ResponseWriter, r *http.Re
 
 	data := &AdminDashboardPageData{
 		ActivePage: "admin",
+		IsAdmin:    isAdminRequest(r),
 		User:       user,
 		Stats:      stats,
 	}
@@ -157,6 +159,7 @@ type UserManagementHandler struct {
 
 type UserManagementPageData struct {
 	ActivePage string
+	IsAdmin    bool
 	User       *models.User
 	Users      []*models.User
 	Total      int
@@ -217,6 +220,7 @@ func (h *UserManagementHandler) UserManagementPage(w http.ResponseWriter, r *htt
 		log.Printf("User management: failed to get user count: %v", err)
 		h.renderPage(w, http.StatusOK, &UserManagementPageData{
 			ActivePage: "admin",
+			IsAdmin:    isAdminRequest(r),
 			User:       user,
 			Users:      users,
 			Error:      "Failed to get user count",
@@ -228,6 +232,7 @@ func (h *UserManagementHandler) UserManagementPage(w http.ResponseWriter, r *htt
 
 	data := &UserManagementPageData{
 		ActivePage: "admin",
+		IsAdmin:    isAdminRequest(r),
 		User:       user,
 		Users:      users,
 		Total:      total,

--- a/internal/handlers/dashboard.go
+++ b/internal/handlers/dashboard.go
@@ -18,6 +18,7 @@ type DashboardHandler struct {
 
 type DashboardPageData struct {
 	ActivePage string
+	IsAdmin    bool
 	User       *models.User
 	Stats      *events.DashboardStats
 	Activities []*events.ActivityItem
@@ -57,6 +58,7 @@ func (h *DashboardHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Dashboard: failed to load recent activity for user %d: %v", user.ID, err)
 		h.renderPage(w, http.StatusOK, &DashboardPageData{
 			ActivePage: "dashboard",
+			IsAdmin:    isAdminRequest(r),
 			User:       user,
 			Stats:      stats,
 			Error:      "Failed to load recent activity",
@@ -66,6 +68,7 @@ func (h *DashboardHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 
 	data := &DashboardPageData{
 		ActivePage: "dashboard",
+		IsAdmin:    isAdminRequest(r),
 		User:       user,
 		Stats:      stats,
 		Activities: activity,

--- a/internal/handlers/events_web.go
+++ b/internal/handlers/events_web.go
@@ -30,6 +30,7 @@ type EventWebHandlers struct {
 
 type EventListPageData struct {
 	ActivePage string
+	IsAdmin    bool
 	Events     []*models.EventWithStats
 	Total      int
 	Page       int
@@ -42,6 +43,7 @@ type EventListPageData struct {
 
 type EventFormPageData struct {
 	ActivePage      string
+	IsAdmin         bool
 	Event           *models.Event
 	Questions       []*models.PreferenceQuestion
 	Themes          []*models.Template
@@ -53,6 +55,7 @@ type EventFormPageData struct {
 
 type EventDetailPageData struct {
 	ActivePage string
+	IsAdmin    bool
 	Event      *models.Event
 	CSRFToken  string
 	Error      string
@@ -119,6 +122,7 @@ func (h *EventWebHandlers) ListEventsPage(w http.ResponseWriter, r *http.Request
 
 	data := &EventListPageData{
 		ActivePage: "events",
+		IsAdmin:    isAdminRequest(r),
 		Events:     eventList,
 		Total:      len(eventList),
 		Page:       page,
@@ -164,6 +168,7 @@ func (h *EventWebHandlers) NewEventForm(w http.ResponseWriter, r *http.Request) 
 
 	data := &EventFormPageData{
 		ActivePage: "events",
+		IsAdmin:    isAdminRequest(r),
 		Event: &models.Event{
 			MaxPlusOnes:    0,
 			AllowMaybeRSVP: true,
@@ -209,6 +214,7 @@ func (h *EventWebHandlers) EditEventForm(w http.ResponseWriter, r *http.Request)
 
 	data := &EventFormPageData{
 		ActivePage:      "events",
+		IsAdmin:         isAdminRequest(r),
 		Event:           event,
 		Questions:       []*models.PreferenceQuestion{},
 		Themes:          themes,
@@ -237,6 +243,7 @@ func (h *EventWebHandlers) GetEventPage(w http.ResponseWriter, r *http.Request) 
 
 	data := &EventDetailPageData{
 		ActivePage: "events",
+		IsAdmin:    isAdminRequest(r),
 		Event:      event,
 		CSRFToken:  csrfToken,
 	}

--- a/internal/handlers/invites_web.go
+++ b/internal/handlers/invites_web.go
@@ -99,6 +99,7 @@ func (h *InviteWebHandlers) ListInvitesPage(w http.ResponseWriter, r *http.Reque
 
 	data := map[string]interface{}{
 		"ActivePage": "events",
+		"IsAdmin":    isAdminRequest(r),
 		"EventID":    eventID,
 		"EventTitle": event.Title,
 		"Invites":    resp.Invites,

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -47,12 +47,13 @@ type MetricsHandler struct {
 }
 
 type MetricsPageData struct {
-	ActivePage string
-	User       *models.User
-	Stats      *AdminMetricsStats
-	EmailQueue *EmailQueueMetrics
-	DBPool     *DBPoolMetrics
-	Error      string
+	ActivePage  string
+	IsAdmin     bool
+	User        *models.User
+	Stats       *AdminMetricsStats
+	EmailQueue  *EmailQueueMetrics
+	DBPool      *DBPoolMetrics
+	Error       string
 	GeneratedAt time.Time
 }
 
@@ -76,6 +77,7 @@ func (h *MetricsHandler) MetricsPage(w http.ResponseWriter, r *http.Request) {
 
 	data := &MetricsPageData{
 		ActivePage:  "admin",
+		IsAdmin:     isAdminRequest(r),
 		User:        user,
 		GeneratedAt: time.Now(),
 	}

--- a/internal/handlers/nav.go
+++ b/internal/handlers/nav.go
@@ -1,0 +1,15 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/lenaxia/tinyrsvp/internal/auth"
+)
+
+// isAdminRequest reports whether the authenticated user for r has the admin
+// role. Used by page handlers to decide whether to render admin-only UI such
+// as the Admin navigation link.
+func isAdminRequest(r *http.Request) bool {
+	user, ok := auth.UserFromContext(r.Context())
+	return ok && user.IsAdmin()
+}

--- a/internal/handlers/rsvp_summary.go
+++ b/internal/handlers/rsvp_summary.go
@@ -42,6 +42,7 @@ func (h *RSVPSummaryHandler) SetTemplates(tmpl *template.Template) {
 
 type RSVPSummaryData struct {
 	ActivePage    string
+	IsAdmin       bool
 	Event         *models.Event
 	Stats         *repositories.RSVPStats
 	RSVPs         []*models.RSVP
@@ -113,6 +114,7 @@ func (h *RSVPSummaryHandler) GetRSVPSummary(w http.ResponseWriter, r *http.Reque
 
 	data := &RSVPSummaryData{
 		ActivePage:    "events",
+		IsAdmin:       isAdminRequest(r),
 		Event:         event,
 		Stats:         stats,
 		RSVPs:         rsvps,

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -142,6 +142,7 @@ type SettingsHandler struct {
 
 type SettingsPageData struct {
 	ActivePage string
+	IsAdmin    bool
 	User       *models.User
 	Settings   SettingsView
 	Error      string
@@ -169,6 +170,7 @@ func (h *SettingsHandler) SettingsPage(w http.ResponseWriter, r *http.Request) {
 
 	data := &SettingsPageData{
 		ActivePage: "admin",
+		IsAdmin:    isAdminRequest(r),
 		User:       user,
 		Settings:   view,
 	}

--- a/internal/handlers/template_editor.go
+++ b/internal/handlers/template_editor.go
@@ -251,10 +251,12 @@ func (h *TemplateEditorHandlers) GetEditorPage(w http.ResponseWriter, r *http.Re
 		Template   *models.Template
 		User       *models.User
 		ActivePage string
+		IsAdmin    bool
 	}{
 		Template:   editable.Template,
 		User:       user,
 		ActivePage: "templates",
+		IsAdmin:    isAdminRequest(r),
 	}
 
 	h.renderPage(w, http.StatusOK, data)

--- a/internal/middleware/metrics_allowlist.go
+++ b/internal/middleware/metrics_allowlist.go
@@ -1,0 +1,84 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// loopbackCIDRs are the networks always permitted to scrape /metrics, even when
+// METRICS_TRUSTED_IPS is unset. This keeps same-host Prometheus scraping
+// working out of the box while closing public exposure.
+var loopbackCIDRs = []string{
+	"127.0.0.0/8",
+	"::1/128",
+}
+
+// MetricsIPAllowlist returns a middleware that restricts access to the wrapped
+// handler to loopback addresses and any explicitly trusted IPs/CIDRs.
+//
+// When trustedIPs is empty, only loopback (127.0.0.0/8, ::1) is permitted.
+// Prometheus cannot authenticate via browser session cookies, so an IP
+// allowlist is the conventional way to protect a scrape endpoint. Operators
+// scraping through a reverse proxy or from another host set
+// METRICS_TRUSTED_IPS (comma-separated IPs or CIDRs) to the scraper address.
+//
+// The client IP is read via GetRealIP (set by the RealIP middleware from
+// X-Real-IP / X-Forwarded-For) so the allowlist works behind a proxy.
+func MetricsIPAllowlist(trustedIPs []string) func(http.Handler) http.Handler {
+	parsed := mustParseCIDRs(append(loopbackCIDRs, trustedIPs...))
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := clientIPForAllowlist(r)
+			if ip == nil {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			for _, network := range parsed {
+				if network.Contains(ip) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+			http.Error(w, "forbidden", http.StatusForbidden)
+		})
+	}
+}
+
+func clientIPForAllowlist(r *http.Request) net.IP {
+	raw := GetRealIP(r.Context())
+	if raw == "" {
+		raw = r.RemoteAddr
+	}
+	// Strip the port for both "host:port" and "[host]:port" forms.
+	if host, _, err := net.SplitHostPort(raw); err == nil {
+		raw = host
+	}
+	return net.ParseIP(strings.TrimSpace(raw))
+}
+
+func mustParseCIDRs(entries []string) []*net.IPNet {
+	networks := make([]*net.IPNet, 0, len(entries))
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if !strings.Contains(entry, "/") {
+			if ip := net.ParseIP(entry); ip != nil {
+				if ip.To4() != nil {
+					entry += "/32"
+				} else {
+					entry += "/128"
+				}
+			}
+		}
+		_, network, err := net.ParseCIDR(entry)
+		if err != nil {
+			continue
+		}
+		networks = append(networks, network)
+	}
+	return networks
+}

--- a/internal/middleware/metrics_allowlist_test.go
+++ b/internal/middleware/metrics_allowlist_test.go
@@ -1,0 +1,149 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMetricsIPAllowlist(t *testing.T) {
+	tests := []struct {
+		name        string
+		trustedIPs  []string
+		realIP      string
+		remoteAddr  string
+		wantAllowed bool
+		wantStatus  int
+	}{
+		{
+			name:        "loopback allowed by default (empty allowlist, ipv4 loopback)",
+			trustedIPs:  nil,
+			realIP:      "",
+			remoteAddr:  "127.0.0.1:40000",
+			wantAllowed: true,
+		},
+		{
+			name:        "loopback allowed by default (ipv6 loopback)",
+			trustedIPs:  nil,
+			realIP:      "",
+			remoteAddr:  "[::1]:40000",
+			wantAllowed: true,
+		},
+		{
+			name:        "non-loopback denied by default",
+			trustedIPs:  nil,
+			realIP:      "",
+			remoteAddr:  "203.0.113.5:40000",
+			wantAllowed: false,
+			wantStatus:  http.StatusForbidden,
+		},
+		{
+			name:        "explicit trusted IP allowed",
+			trustedIPs:  []string{"10.0.0.5"},
+			realIP:      "10.0.0.5",
+			remoteAddr:  "172.16.0.1:40000",
+			wantAllowed: true,
+		},
+		{
+			name:        "non-trusted IP denied when allowlist set",
+			trustedIPs:  []string{"10.0.0.5"},
+			realIP:      "10.0.0.9",
+			remoteAddr:  "10.0.0.9:40000",
+			wantAllowed: false,
+			wantStatus:  http.StatusForbidden,
+		},
+		{
+			name:        "trusted CIDR range allowed",
+			trustedIPs:  []string{"172.19.0.0/16"},
+			realIP:      "172.19.0.42",
+			remoteAddr:  "172.19.0.42:40000",
+			wantAllowed: true,
+		},
+		{
+			name:        "IP outside trusted CIDR denied",
+			trustedIPs:  []string{"172.19.0.0/16"},
+			realIP:      "172.18.0.42",
+			remoteAddr:  "172.18.0.42:40000",
+			wantAllowed: false,
+			wantStatus:  http.StatusForbidden,
+		},
+		{
+			name:        "real IP from X-Forwarded-For honored when allowlist set",
+			trustedIPs:  []string{"192.168.1.10"},
+			realIP:      "192.168.1.10",
+			remoteAddr:  "10.0.0.1:40000",
+			wantAllowed: true,
+		},
+		{
+			name:        "malformed remote addr denied (does not panic)",
+			trustedIPs:  nil,
+			realIP:      "",
+			remoteAddr:  "not-an-ip",
+			wantAllowed: false,
+			wantStatus:  http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := MetricsIPAllowlist(tt.trustedIPs)(next)
+
+			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.realIP != "" {
+				ctx := context.WithValue(req.Context(), RealIPKey, tt.realIP)
+				req = req.WithContext(ctx)
+			}
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if called != tt.wantAllowed {
+				t.Fatalf("allowed=%v, want %v (status=%d)", called, tt.wantAllowed, rec.Code)
+			}
+			if !tt.wantAllowed && rec.Code != tt.wantStatus {
+				t.Errorf("status=%d, want %d", rec.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestMetricsIPAllowlistDefaultIsLoopback(t *testing.T) {
+	t.Run("loopback ipv4 default allowed", func(t *testing.T) {
+		called := false
+		handler := MetricsIPAllowlist(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		req.RemoteAddr = "127.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if !called {
+			t.Error("loopback IPv4 must be allowed by default")
+		}
+	})
+
+	t.Run("public IP default denied", func(t *testing.T) {
+		called := false
+		handler := MetricsIPAllowlist(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		req.RemoteAddr = "8.8.8.8:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if called {
+			t.Error("public IP must be denied by default")
+		}
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("status=%d, want 403", rec.Code)
+		}
+	})
+}

--- a/templates/web/partials/navigation.html
+++ b/templates/web/partials/navigation.html
@@ -19,7 +19,7 @@
         </li>
         <li><a href="/" class="app-nav-link {{if eq .ActivePage "dashboard"}}active{{end}}" {{if eq .ActivePage "dashboard"}}aria-current="page"{{end}}>Dashboard</a></li>
         <li><a href="/events" class="app-nav-link {{if eq .ActivePage "events"}}active{{end}}" {{if eq .ActivePage "events"}}aria-current="page"{{end}}>Events</a></li>
-        <li><a href="/admin" class="app-nav-link {{if eq .ActivePage "admin"}}active{{end}}" {{if eq .ActivePage "admin"}}aria-current="page"{{end}}>Admin</a></li>
+        {{if .IsAdmin}}<li><a href="/admin" class="app-nav-link {{if eq .ActivePage "admin"}}active{{end}}" {{if eq .ActivePage "admin"}}aria-current="page"{{end}}>Admin</a></li>{{end}}
     </ul>
 </nav>
 {{end}}

--- a/templates/web/partials/navigation_test.go
+++ b/templates/web/partials/navigation_test.go
@@ -1,0 +1,71 @@
+package web
+
+import (
+	"bytes"
+	"html/template"
+	"os"
+	"strings"
+	"testing"
+)
+
+type navTestData struct {
+	ActivePage string
+	IsAdmin    bool
+}
+
+func parseNavTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	raw, err := os.ReadFile("navigation.html")
+	if err != nil {
+		t.Fatalf("Failed to read navigation.html: %v", err)
+	}
+	tmpl, err := template.New("navigation").Parse(string(raw))
+	if err != nil {
+		t.Fatalf("Failed to parse navigation.html: %v", err)
+	}
+	return tmpl
+}
+
+func TestNavigationAdminLinkGatedByRole(t *testing.T) {
+	tmpl := parseNavTemplate(t)
+
+	t.Run("admin link shown for admin user", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, navTestData{ActivePage: "dashboard", IsAdmin: true}); err != nil {
+			t.Fatalf("template execute failed: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, `href="/admin"`) {
+			t.Error("expected Admin nav link to be present when IsAdmin=true")
+		}
+	})
+
+	t.Run("admin link hidden for non-admin user", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, navTestData{ActivePage: "dashboard", IsAdmin: false}); err != nil {
+			t.Fatalf("template execute failed: %v", err)
+		}
+		out := buf.String()
+		if strings.Contains(out, `href="/admin"`) {
+			t.Error("expected Admin nav link to be absent when IsAdmin=false")
+		}
+	})
+}
+
+func TestNavigationAlwaysShowsDashboardAndEvents(t *testing.T) {
+	tmpl := parseNavTemplate(t)
+
+	for _, isAdmin := range []bool{true, false} {
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, navTestData{ActivePage: "dashboard", IsAdmin: isAdmin}); err != nil {
+			t.Fatalf("template execute failed (isAdmin=%v): %v", isAdmin, err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, `href="/"`) {
+			t.Errorf("Dashboard link missing (isAdmin=%v)", isAdmin)
+		}
+		if !strings.Contains(out, `href="/events"`) {
+			t.Errorf("Events link missing (isAdmin=%v)", isAdmin)
+		}
+	}
+}

--- a/templates/web/rsvp_summary_test.go
+++ b/templates/web/rsvp_summary_test.go
@@ -13,6 +13,7 @@ import (
 
 type RSVPSummaryData struct {
 	ActivePage    string
+	IsAdmin       bool
 	Event         *models.Event
 	Stats         *repositories.RSVPStats
 	RSVPs         []*models.RSVP


### PR DESCRIPTION
## Summary

Addresses two open security/UX bugs. Closes #7, closes #13.

## #7 — `/metrics` endpoint unprotected (High)

The raw Prometheus `/metrics` endpoint was registered with no middleware (`main.go` even logged `protection: none`), exposing internal operational data publicly.

**Approach:** IP allowlist. Prometheus cannot authenticate via browser session cookies, so an allowlist is the conventional way to protect a scrape endpoint. The existing human-readable `/admin/metrics` dashboard (behind admin auth) is unchanged.

- New `MetricsIPAllowlist` middleware permits **loopback only** (`127.0.0.0/8`, `::1`) by default — safe for same-host Prometheus out of the box.
- New `METRICS_TRUSTED_IPS` env var (comma-separated IPs or CIDRs) extends the allowlist — set it to the scraper IP or a Docker subnet (e.g. `172.19.0.0/16`).
- Client IP read via `GetRealIP` (set from `X-Real-IP`/`X-Forwarded-For` by the existing `RealIP` middleware), so it works behind a reverse proxy.
- Extracted shared IP/CIDR parsing + validation into `config/ip_list.go`, reused by forward-auth (removed the duplicated validation in `forward_auth.go`).
- Documented in `.env.example`.

## #13 — Admin nav link visible to all authenticated users (Medium)

The Admin link was rendered unconditionally; non-admins clicking it got a 403.

- Added `IsAdmin bool` to each staff page-data struct and the invites data map.
- Populated via a shared `isAdminRequest(r)` helper (`internal/handlers/nav.go`) reading the role from the auth context.
- Gated the link with `{{if .IsAdmin}}` in `navigation.html`.
- Guest pages (rsvp, confirmation, unsubscribe) don't render the nav and are unaffected.

## Tests

- `internal/middleware/metrics_allowlist_test.go` — 11 cases: loopback default-allow, public default-deny, explicit IP/CIDR allow+deny, X-Forwarded-For honored, malformed addr doesn't panic.
- `internal/config/metrics_test.go` — env parsing + validation (valid mixed, invalid IP/CIDR, empty=valid).
- `templates/web/partials/navigation_test.go` — Admin link shown for admin, hidden for non-admin; Dashboard/Events always present.
- Updated `forward_auth_test.go` expectations for the improved (more specific) error messages.

## Verification
- `go build ./...` clean
- `go vet ./internal/... ./templates/... ./cmd/...` clean
- All non-browser tests pass (39 packages). Browser tests (`tests/ux_playwright`) fail only due to missing `libglib-2.0.so.0` in this sandbox — unrelated to these changes.