### PR TITLE
fix: wire ignored server/session config values into runtime behavior

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -197,7 +197,7 @@ func main() {
 	}
 	logger.Info("Email template renderer initialized")
 
-	sessionMgr := auth.NewSessionManager(sessionRepo, strings.HasPrefix(cfg.Server.BaseURL, "https://"))
+	sessionMgr := auth.NewSessionManager(sessionRepo, strings.HasPrefix(cfg.Server.BaseURL, "https://"), cfg.Security.SessionDuration)
 	userService := auth.NewUserService(userRepo)
 	authChecker := auth.NewAuthorizationChecker()
 
@@ -751,9 +751,9 @@ func main() {
 	server := &http.Server{
 		Addr:         addr,
 		Handler:      router,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		ReadTimeout:  cfg.Server.ReadTimeout,
+		WriteTimeout: cfg.Server.WriteTimeout,
+		IdleTimeout:  cfg.Server.IdleTimeout,
 	}
 
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())

--- a/cmd/server/main_integration_test.go
+++ b/cmd/server/main_integration_test.go
@@ -74,7 +74,7 @@ func TestMain_RouterIntegration(t *testing.T) {
 	templateValidator := templates.NewValidator(templateEngine)
 	templateService := templates.NewService(templateRepo, templateValidator)
 
-	sessionMgr := auth.NewSessionManager(sessionRepo, false)
+	sessionMgr := auth.NewSessionManager(sessionRepo, false, 0)
 	userService := auth.NewUserService(userRepo)
 	authChecker := auth.NewAuthorizationChecker()
 
@@ -333,7 +333,7 @@ func TestMain_RouterIntegration_AuthenticatedRoutes(t *testing.T) {
 	templateValidator := templates.NewValidator(templateEngine)
 	templateService := templates.NewService(templateRepo, templateValidator)
 
-	sessionMgr := auth.NewSessionManager(sessionRepo, false)
+	sessionMgr := auth.NewSessionManager(sessionRepo, false, 0)
 	userService := auth.NewUserService(userRepo)
 	authChecker := auth.NewAuthorizationChecker()
 
@@ -536,7 +536,7 @@ func TestMain_RouterIntegration_MiddlewareChain(t *testing.T) {
 		t.Fatalf("Failed to create test user: %v", err)
 	}
 
-	sessionMgr := auth.NewSessionManager(sessionRepo, false)
+	sessionMgr := auth.NewSessionManager(sessionRepo, false, 0)
 	userService := auth.NewUserService(userRepo)
 	authChecker := auth.NewAuthorizationChecker()
 

--- a/docs/01_WORKLOG/0182_2026-08-01_wire_ignored_configs.md
+++ b/docs/01_WORKLOG/0182_2026-08-01_wire_ignored_configs.md
@@ -1,0 +1,32 @@
+# Worklog: Wire Ignored Server/Session Config Values
+
+**Date:** 2026-08-01  
+**Branch:** `fix/wire-ignored-configs`  
+**PR:** #67
+
+## Summary
+
+Cluster 2 from the tech-debt review: three config values were loaded, validated, and displayed in the admin settings page but never applied to runtime behavior. Wired them in.
+
+## Changes
+
+1. **Server timeouts** — `http.Server` was built with hardcoded `15s/15s/60s` literals, ignoring `SERVER_READ_TIMEOUT`/`SERVER_WRITE_TIMEOUT`/`SERVER_IDLE_TIMEOUT`. Now uses the configured values (`cfg.Server.{Read,Write,Idle}Timeout`).
+2. **Session duration** — the session manager used a package constant (7 days) regardless of `SECURITY_SESSION_DURATION`. `NewSessionManager` now accepts a `sessionDuration time.Duration` (`<=0` falls back to the 7-day default); `cmd/server/main.go` passes the configured value. Updated all callers (main, uxserver, tests).
+
+## Explicitly NOT changed
+
+- **`TokenExpiry`** — the hardcoded 30-day invite expiry already equals the config default (720h); threading config into invite handlers for a value that matches is not worth the churn.
+- **`SECURITY_HMAC_SECRET`** — genuinely unused (the token generator consumes `TOKEN_SECRET`), but it is validated and surfaced on the admin settings page, suggesting possible intent. Worklog 0172's claim that it is "used by main.go for token generation" is factually wrong. **Left in place pending a product decision** rather than a silent removal, per the caution about removing potentially-intended code.
+
+## Tests
+
+- New: `TestSessionManager_CreateSession_CustomDuration` (48h) and `TestSessionManager_CreateSession_ZeroDurationUsesDefault` (0 → 7-day default).
+- Updated all existing `NewSessionManager` callers to pass the duration arg.
+- Full suite: all 39 non-browser packages pass; `go build`/`go vet` clean.
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** All non-browser tests pass  
+**Confidence:** HIGH  
+**Production Ready:** Yes

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -21,14 +21,21 @@ const (
 )
 
 type sessionManager struct {
-	repo   repositories.SessionRepository
-	secure bool
+	repo            repositories.SessionRepository
+	secure          bool
+	sessionDuration time.Duration
 }
 
-func NewSessionManager(repo repositories.SessionRepository, secure bool) SessionManager {
+// NewSessionManager creates a SessionManager. If sessionDuration is <= 0, the
+// package default (7 days) is used.
+func NewSessionManager(repo repositories.SessionRepository, secure bool, sessionDuration time.Duration) SessionManager {
+	if sessionDuration <= 0 {
+		sessionDuration = SessionDuration
+	}
 	return &sessionManager{
-		repo:   repo,
-		secure: secure,
+		repo:            repo,
+		secure:          secure,
+		sessionDuration: sessionDuration,
 	}
 }
 
@@ -46,7 +53,7 @@ func (m *sessionManager) CreateSession(ctx context.Context, userID int64, r *htt
 		ID:             sessionID,
 		UserID:         userID,
 		CreatedAt:      now,
-		ExpiresAt:      now.Add(SessionDuration),
+		ExpiresAt:      now.Add(m.sessionDuration),
 		LastAccessedAt: now,
 		IPAddress:      &ipAddress,
 		UserAgent:      &userAgent,
@@ -94,7 +101,7 @@ func (m *sessionManager) SetSessionCookie(w http.ResponseWriter, sessionID strin
 		Name:     SessionCookieName,
 		Value:    sessionID,
 		Path:     "/",
-		MaxAge:   int(SessionDuration.Seconds()),
+		MaxAge:   int(m.sessionDuration.Seconds()),
 		Secure:   m.secure,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -24,7 +24,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	r := httptest.NewRequest("GET", "/", nil)
 	r.Header.Set("X-Forwarded-For", "203.0.113.1")
@@ -65,6 +65,48 @@ func TestSessionManager_CreateSession(t *testing.T) {
 	}
 }
 
+func TestSessionManager_CreateSession_CustomDuration(t *testing.T) {
+	mockRepo := &MockSessionRepository{
+		CreateFunc: func(ctx context.Context, session *models.Session) error {
+			return nil
+		},
+	}
+
+	mgr := NewSessionManager(mockRepo, true, 48*time.Hour)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	session, err := mgr.CreateSession(context.Background(), 123, r)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	expectedExpiry := time.Now().Add(48 * time.Hour)
+	if session.ExpiresAt.Sub(expectedExpiry) > time.Minute {
+		t.Errorf("Expected expiry around %v (config duration), got %v", expectedExpiry, session.ExpiresAt)
+	}
+}
+
+func TestSessionManager_CreateSession_ZeroDurationUsesDefault(t *testing.T) {
+	mockRepo := &MockSessionRepository{
+		CreateFunc: func(ctx context.Context, session *models.Session) error {
+			return nil
+		},
+	}
+
+	mgr := NewSessionManager(mockRepo, true, 0)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	session, err := mgr.CreateSession(context.Background(), 123, r)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	expectedExpiry := time.Now().Add(7 * 24 * time.Hour)
+	if session.ExpiresAt.Sub(expectedExpiry) > time.Minute {
+		t.Errorf("Expected expiry around %v (default), got %v", expectedExpiry, session.ExpiresAt)
+	}
+}
+
 func TestSessionManager_CreateSession_UniqueIDs(t *testing.T) {
 	mockRepo := &MockSessionRepository{
 		CreateFunc: func(ctx context.Context, session *models.Session) error {
@@ -72,7 +114,7 @@ func TestSessionManager_CreateSession_UniqueIDs(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	r := httptest.NewRequest("GET", "/", nil)
 
@@ -106,7 +148,7 @@ func TestSessionManager_GetSession_Valid(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	session, err := mgr.GetSession(context.Background(), sessionID)
 	if err != nil {
@@ -142,7 +184,7 @@ func TestSessionManager_GetSession_Expired(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	session, err := mgr.GetSession(context.Background(), sessionID)
 	if err == nil {
@@ -171,7 +213,7 @@ func TestSessionManager_RefreshSession(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	err := mgr.RefreshSession(context.Background(), sessionID)
 	if err != nil {
@@ -190,7 +232,7 @@ func TestSessionManager_RefreshSession_NotFound(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	err := mgr.RefreshSession(context.Background(), "nonexistent")
 	if err == nil {
@@ -211,7 +253,7 @@ func TestSessionManager_DeleteSession(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	err := mgr.DeleteSession(context.Background(), sessionID)
 	if err != nil {
@@ -230,7 +272,7 @@ func TestSessionManager_DeleteSession_NotFound(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	err := mgr.DeleteSession(context.Background(), "nonexistent")
 	if err == nil {
@@ -251,7 +293,7 @@ func TestSessionManager_DeleteUserSessions(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	err := mgr.DeleteUserSessions(context.Background(), userID)
 	if err != nil {
@@ -270,7 +312,7 @@ func TestSessionManager_CleanupExpired(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	count, err := mgr.CleanupExpired(context.Background())
 	if err != nil {
@@ -289,7 +331,7 @@ func TestSessionManager_CleanupExpired_Error(t *testing.T) {
 		},
 	}
 
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	_, err := mgr.CleanupExpired(context.Background())
 	if err == nil {
@@ -299,7 +341,7 @@ func TestSessionManager_CleanupExpired_Error(t *testing.T) {
 
 func TestSessionManager_SetSessionCookie(t *testing.T) {
 	mockRepo := &MockSessionRepository{}
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	w := httptest.NewRecorder()
 	sessionID := "test-session-id-123"
@@ -350,7 +392,7 @@ func TestSessionManager_SetSessionCookie(t *testing.T) {
 
 func TestSessionManager_SetSessionCookie_NonSecure(t *testing.T) {
 	mockRepo := &MockSessionRepository{}
-	mgr := NewSessionManager(mockRepo, false)
+	mgr := NewSessionManager(mockRepo, false, 0)
 
 	w := httptest.NewRecorder()
 	sessionID := "test-session-id"
@@ -384,7 +426,7 @@ func TestSessionManager_SetSessionCookie_NonSecure(t *testing.T) {
 
 func TestSessionManager_ClearSessionCookie(t *testing.T) {
 	mockRepo := &MockSessionRepository{}
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	w := httptest.NewRecorder()
 
@@ -417,7 +459,7 @@ func TestSessionManager_ClearSessionCookie(t *testing.T) {
 
 func TestSessionManager_GetSessionFromRequest(t *testing.T) {
 	mockRepo := &MockSessionRepository{}
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	sessionID := "test-session-id"
 	r := httptest.NewRequest("GET", "/", nil)
@@ -438,7 +480,7 @@ func TestSessionManager_GetSessionFromRequest(t *testing.T) {
 
 func TestSessionManager_GetSessionFromRequest_NoCookie(t *testing.T) {
 	mockRepo := &MockSessionRepository{}
-	mgr := NewSessionManager(mockRepo, true)
+	mgr := NewSessionManager(mockRepo, true, 0)
 
 	r := httptest.NewRequest("GET", "/", nil)
 

--- a/internal/middleware/rbac_integration_test.go
+++ b/internal/middleware/rbac_integration_test.go
@@ -41,7 +41,7 @@ func setupIntegrationTest(t *testing.T) (auth.SessionManager, auth.UserService, 
 	userRepo := repositories.NewUserRepository(database)
 	sessionRepo := repositories.NewSessionRepository(database)
 
-	sessionMgr := auth.NewSessionManager(sessionRepo, false)
+	sessionMgr := auth.NewSessionManager(sessionRepo, false, 0)
 	userService := auth.NewUserService(userRepo)
 
 	cleanup := func() {

--- a/tests/e2e/auth_flow_test.go
+++ b/tests/e2e/auth_flow_test.go
@@ -61,7 +61,7 @@ func setupTestServer(t *testing.T) *testServer {
 	userRepo := repositories.NewUserRepository(database)
 	sessionRepo := repositories.NewSessionRepository(database)
 
-	sessionMgr := auth.NewSessionManager(sessionRepo, false)
+	sessionMgr := auth.NewSessionManager(sessionRepo, false, 0)
 	userService := auth.NewUserService(userRepo)
 	authChecker := auth.NewAuthorizationChecker()
 

--- a/tests/e2e/invite_flow_test.go
+++ b/tests/e2e/invite_flow_test.go
@@ -72,7 +72,7 @@ func setupInviteTestServer(t *testing.T) *inviteTestServer {
 	eventRepo := repositories.NewEventRepository(database)
 	inviteRepo := repositories.NewInviteRepository(database)
 
-	sessionMgr := auth.NewSessionManager(sessionRepo, false)
+	sessionMgr := auth.NewSessionManager(sessionRepo, false, 0)
 	userService := auth.NewUserService(userRepo)
 	authChecker := auth.NewAuthorizationChecker()
 

--- a/tests/integration/post_merge_verification_test.go
+++ b/tests/integration/post_merge_verification_test.go
@@ -115,7 +115,7 @@ func setupVerificationServer(t *testing.T) (*httptest.Server, int64, db.Database
 	database, userRepo, eventRepo, inviteRepo, emailQueueRepo, sessionRepo, adminUserID := setupVerificationDB(t)
 
 	userService := auth.NewUserService(userRepo)
-	sessionMgr := auth.NewSessionManager(sessionRepo, false)
+	sessionMgr := auth.NewSessionManager(sessionRepo, false, 0)
 	authChecker := auth.NewAuthorizationChecker()
 	requireAuth := middleware.TestRequireAuth(sessionMgr, userService)
 	requireAdmin := middleware.RequireAdmin(authChecker)

--- a/tests/uxserver/server.go
+++ b/tests/uxserver/server.go
@@ -160,7 +160,7 @@ func Setup(opts Options) (*Server, func(), error) {
 	emailQueueRepo := repositories.NewEmailQueueRepository(database)
 	templateRepo := repositories.NewTemplateRepository(database)
 
-	sessionMgr := auth.NewSessionManager(sessionRepo, false)
+	sessionMgr := auth.NewSessionManager(sessionRepo, false, 0)
 	userService := auth.NewUserService(userRepo)
 	authChecker := auth.NewAuthorizationChecker()
 


### PR DESCRIPTION
## Summary

Three config values were loaded, validated, and displayed in admin settings but never applied to runtime behavior:

1. **Server timeouts** — `http.Server` was built with hardcoded `15s/15s/60s` literals, ignoring `SERVER_READ_TIMEOUT`/`SERVER_WRITE_TIMEOUT`/`SERVER_IDLE_TIMEOUT`. Now uses the configured values.
2. **Session duration** — the session manager used a package constant (7 days) regardless of `SECURITY_SESSION_DURATION`. `NewSessionManager` now accepts a duration (`<=0` falls back to the 7-day default); `main.go` passes the configured value. Added tests for custom duration and default fallback.

## Explicitly NOT changed
- **`TokenExpiry`** — the hardcoded 30-day invite expiry already equals the config default (720h); threading config into invite handlers for a value that matches is not worth the churn.
- **`SECURITY_HMAC_SECRET`** — genuinely unused (the token generator consumes `TOKEN_SECRET`), but it is validated and surfaced on the admin settings page, suggesting possible intent. Worklog 0172's claim that it is "used by main.go for token generation" is factually wrong. **Left in place pending a product decision** rather than a silent removal, per the caution about removing potentially-intended code.

## Verification
`go build ./...` clean, `go vet ./...` clean, all 39 non-browser test packages pass.