### PR TITLE
feat: wire up preference questions UI (#11)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -524,7 +524,7 @@ func main() {
 	}
 	logger.Info("Event detail templates loaded successfully")
 
-	eventWebHandlers := handlers.NewEventWebHandlers(eventService, templateService, eventListTemplates, eventFormTemplates, eventDetailTemplates)
+	eventWebHandlers := handlers.NewEventWebHandlers(eventService, templateService, questionService, eventListTemplates, eventFormTemplates, eventDetailTemplates)
 
 	customizationHandlers.SetTemplates(customizationTemplates)
 

--- a/docs/01_WORKLOG/0183_2026-08-01_preference_questions_ui.md
+++ b/docs/01_WORKLOG/0183_2026-08-01_preference_questions_ui.md
@@ -1,0 +1,39 @@
+# Worklog: Wire Up Preference Questions UI
+
+**Date:** 2026-08-01  
+**Branch:** `feat/preference-questions-ui`  
+**Issue:** #11
+
+## Summary
+
+The preference-questions backend (table, repository, service, API at `/api/events/{id}/questions`) was 100% complete, but the event form UI was gated behind a 🚧 "Coming Soon" overlay with disabled inputs. Wired the UI end-to-end.
+
+## Changes
+
+- **`internal/handlers/events_web.go`**
+  - Added `questionService events.QuestionService` to `EventWebHandlers`; threaded through `NewEventWebHandlers`.
+  - `EditEventForm` now loads existing questions via `GetQuestions` (was hardcoded to empty).
+  - `CreateEventFromForm` creates the submitted questions after event creation (event ID + display order assigned).
+  - `UpdateEventFromForm` calls a new `syncQuestions` helper that reconciles the submitted list with persisted questions (update existing, create new, delete removed, apply order). Only runs while the event is draft, matching the service's "cannot modify questions on published event" rule.
+  - Added `parseQuestionsFromForm` helper that extracts `questions[N][{id,text,type,required,options}]` form fields.
+- **`templates/web/event_form.html`** — removed the "Coming Soon" overlay, enabled all fields, fixed the answer-type select to use the real enum values (`text`/`single_choice`/`multiple_choice` instead of the stale `text`/`choice`), and added hidden `id`, `required` checkbox, and `options` (one-per-line) fields.
+- **`static/js/questions.js`** — add/remove question rows, renumbering of field names, and show/hide the options textarea based on selected answer type.
+- **`cmd/server/main.go` + `tests/uxserver/server.go`** — pass `questionService` to `NewEventWebHandlers`.
+
+## Tests
+
+- New `internal/handlers/questions_form_test.go`: `parseQuestionsFromForm` happy path + empty-row skipping, and create-flow that verifies questions get the created event's ID.
+- Updated `NewEventWebHandlers` callers in tests to pass the new arg.
+- Full suite: all 39 non-browser packages pass; `go build`/`go vet` clean.
+
+## Notes
+
+- The JSON API (`/api/events/{id}/questions`) is unchanged; the form now writes through the same `QuestionService`.
+- `help_text` (wired in an earlier PR) is not surfaced in this UI yet; options are entered one-per-line.
+
+## Status
+
+**Status:** ✅ Complete  
+**Test Pass Rate:** All non-browser tests pass  
+**Confidence:** HIGH  
+**Production Ready:** Yes

--- a/internal/handlers/events_multiday_display_test.go
+++ b/internal/handlers/events_multiday_display_test.go
@@ -102,7 +102,7 @@ func TestEventWebHandlers_EditEventForm_MultiDayDisplay(t *testing.T) {
 				</html>
 			`))
 
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			req := httptest.NewRequest("GET", "/events/1/edit", nil)
 			rctx := chi.NewRouteContext()

--- a/internal/handlers/events_web.go
+++ b/internal/handlers/events_web.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 type EventWebHandlers struct {
 	service         events.Service
 	templateService templates.Service
+	questionService events.QuestionService
 	listTemplates   *template.Template
 	formTemplates   *template.Template
 	detailTemplates *template.Template
@@ -60,10 +62,11 @@ type EventDetailPageData struct {
 	Error      string
 }
 
-func NewEventWebHandlers(service events.Service, templateService templates.Service, listTmpl, formTmpl, detailTmpl *template.Template) *EventWebHandlers {
+func NewEventWebHandlers(service events.Service, templateService templates.Service, questionService events.QuestionService, listTmpl, formTmpl, detailTmpl *template.Template) *EventWebHandlers {
 	return &EventWebHandlers{
 		service:         service,
 		templateService: templateService,
+		questionService: questionService,
 		listTemplates:   listTmpl,
 		formTemplates:   formTmpl,
 		detailTemplates: detailTmpl,
@@ -216,11 +219,20 @@ func (h *EventWebHandlers) EditEventForm(w http.ResponseWriter, r *http.Request)
 		selectedThemeID = defaultTheme.ID
 	}
 
+	questions := []*models.PreferenceQuestion{}
+	if h.questionService != nil {
+		questions, err = h.questionService.GetQuestions(r.Context(), event.ID)
+		if err != nil {
+			HandleError(w, r, err)
+			return
+		}
+	}
+
 	data := &EventFormPageData{
 		ActivePage:      "events",
 		IsAdmin:         isAdminRequest(r),
 		Event:           event,
-		Questions:       []*models.PreferenceQuestion{},
+		Questions:       questions,
 		Themes:          themes,
 		SelectedThemeID: selectedThemeID,
 		Errors:          make(map[string]string),
@@ -270,6 +282,18 @@ func (h *EventWebHandlers) CreateEventFromForm(w http.ResponseWriter, r *http.Re
 	if err := h.service.CreateEvent(r.Context(), event); err != nil {
 		HandleError(w, r, err)
 		return
+	}
+
+	questions := parseQuestionsFromForm(r.Form)
+	if h.questionService != nil {
+		for i := range questions {
+			questions[i].EventID = event.ID
+			questions[i].DisplayOrder = i
+			if err := h.questionService.AddQuestion(r.Context(), questions[i]); err != nil {
+				HandleError(w, r, err)
+				return
+			}
+		}
 	}
 
 	http.Redirect(w, r, fmt.Sprintf("/events/%d", event.ID), http.StatusSeeOther)
@@ -424,7 +448,62 @@ func (h *EventWebHandlers) UpdateEventFromForm(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Questions may only be modified while the event is a draft. On published
+	// (or later) events, ignore submitted questions rather than blocking the
+	// event update.
+	if event.Status == models.EventStatusDraft {
+		if err := h.syncQuestions(r.Context(), id, parseQuestionsFromForm(r.Form)); err != nil {
+			HandleError(w, r, err)
+			return
+		}
+	}
+
 	http.Redirect(w, r, fmt.Sprintf("/events/%d", id), http.StatusSeeOther)
+}
+
+// syncQuestions reconciles the submitted question list with the persisted
+// questions for the event: existing questions are updated, new ones created,
+// removed ones deleted, and display order applied by list position.
+func (h *EventWebHandlers) syncQuestions(ctx context.Context, eventID int64, submitted []*models.PreferenceQuestion) error {
+	if h.questionService == nil {
+		return nil
+	}
+
+	existing, err := h.questionService.GetQuestions(ctx, eventID)
+	if err != nil {
+		return err
+	}
+
+	existingByID := make(map[int64]*models.PreferenceQuestion, len(existing))
+	for _, q := range existing {
+		existingByID[q.ID] = q
+	}
+
+	seen := make(map[int64]bool, len(submitted))
+	for i, q := range submitted {
+		q.EventID = eventID
+		q.DisplayOrder = i
+		if q.ID != 0 {
+			seen[q.ID] = true
+			if err := h.questionService.UpdateQuestion(ctx, q); err != nil {
+				return err
+			}
+		} else {
+			if err := h.questionService.AddQuestion(ctx, q); err != nil {
+				return err
+			}
+		}
+	}
+
+	for id := range existingByID {
+		if !seen[id] {
+			if err := h.questionService.DeleteQuestion(ctx, id); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (h *EventWebHandlers) PublishEventAction(w http.ResponseWriter, r *http.Request) {
@@ -509,7 +588,6 @@ func parseEventFormData(form url.Values) (*models.Event, error) {
 	if len(title) < 3 || len(title) > 200 {
 		return nil, fmt.Errorf("title must be between 3 and 200 characters")
 	}
-
 	startTimeStr := form.Get("start_time")
 	if startTimeStr == "" {
 		return nil, fmt.Errorf("start_time is required")
@@ -619,4 +697,66 @@ func (h *EventWebHandlers) loadThemes(ctx context.Context) ([]*models.Template, 
 	}
 
 	return themes, defaultTheme, nil
+}
+
+// parseQuestionsFromForm extracts the preference questions submitted by the
+// event form. Fields use the shape questions[N][field] where field is one of
+// id, text, type, required, options.
+func parseQuestionsFromForm(form url.Values) []*models.PreferenceQuestion {
+	indexSet := map[int]bool{}
+	for key := range form {
+		start := strings.Index(key, "questions[")
+		if start != 0 {
+			continue
+		}
+		end := strings.Index(key[start:], "]")
+		if end < 0 {
+			continue
+		}
+		idxStr := key[len("questions[") : start+end]
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil {
+			continue
+		}
+		indexSet[idx] = true
+	}
+
+	indices := make([]int, 0, len(indexSet))
+	for idx := range indexSet {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+
+	questions := make([]*models.PreferenceQuestion, 0, len(indices))
+	for _, idx := range indices {
+		q := &models.PreferenceQuestion{}
+
+		if idStr := form.Get(fmt.Sprintf("questions[%d][id]", idx)); idStr != "" {
+			if id, err := strconv.ParseInt(idStr, 10, 64); err == nil {
+				q.ID = id
+			}
+		}
+
+		q.QuestionText = strings.TrimSpace(form.Get(fmt.Sprintf("questions[%d][text]", idx)))
+		q.QuestionType = models.QuestionType(form.Get(fmt.Sprintf("questions[%d][type]", idx)))
+		q.Required = form.Get(fmt.Sprintf("questions[%d][required]", idx)) == "on"
+
+		if optionsStr := form.Get(fmt.Sprintf("questions[%d][options]", idx)); optionsStr != "" {
+			options := []string{}
+			for _, line := range strings.Split(optionsStr, "\n") {
+				if opt := strings.TrimSpace(line); opt != "" {
+					options = append(options, opt)
+				}
+			}
+			if len(options) > 0 {
+				q.SetOptions(options)
+			}
+		}
+
+		if q.QuestionText != "" {
+			questions = append(questions, q)
+		}
+	}
+
+	return questions
 }

--- a/internal/handlers/events_web_integration_test.go
+++ b/internal/handlers/events_web_integration_test.go
@@ -65,7 +65,7 @@ func TestEventWebHandlers_FullWebUIFlow_Integration(t *testing.T) {
 		{{end}}
 	`))
 
-	handlers := NewEventWebHandlers(eventService, nil, tmpl, tmpl, tmpl)
+	handlers := NewEventWebHandlers(eventService, nil, nil, tmpl, tmpl, tmpl)
 
 	ctx := context.Background()
 
@@ -310,7 +310,7 @@ func TestEventWebHandlers_PermissionEnforcement_Integration(t *testing.T) {
 		{{end}}
 	`))
 
-	handlers := NewEventWebHandlers(eventService, nil, tmpl, tmpl, tmpl)
+	handlers := NewEventWebHandlers(eventService, nil, nil, tmpl, tmpl, tmpl)
 
 	ctx := context.Background()
 
@@ -409,7 +409,7 @@ func TestEventWebHandlers_RouterIntegration(t *testing.T) {
 		{{define "event_detail.html"}}<html><body>Detail</body></html>{{end}}
 	`))
 
-	eventWebHandlers := NewEventWebHandlers(eventService, nil, tmpl, tmpl, tmpl)
+	eventWebHandlers := NewEventWebHandlers(eventService, nil, nil, tmpl, tmpl, tmpl)
 
 	authMiddleware := &mockAuthMiddleware{}
 
@@ -503,7 +503,7 @@ func TestEventWebHandlers_CSRFProtection_Integration(t *testing.T) {
 	eventService := events.NewService(eventRepo, nil, validator, authChecker)
 
 	tmpl := template.New("test")
-	handlers := NewEventWebHandlers(eventService, nil, tmpl, tmpl, tmpl)
+	handlers := NewEventWebHandlers(eventService, nil, nil, tmpl, tmpl, tmpl)
 
 	ctx := context.Background()
 

--- a/internal/handlers/events_web_test.go
+++ b/internal/handlers/events_web_test.go
@@ -21,7 +21,7 @@ import (
 func TestNewEventWebHandlers(t *testing.T) {
 	mockService := &mockEventService{}
 	tmpl := template.New("test")
-	handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+	handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 	if handlers == nil {
 		t.Fatal("NewEventWebHandlers returned nil")
@@ -161,7 +161,7 @@ func TestEventWebHandlers_ListEventsPage(t *testing.T) {
 				</html>
 			`))
 
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			req := httptest.NewRequest("GET", "/events"+tt.query, nil)
 			ctx := auth.WithUser(req.Context(), tt.user)
@@ -224,7 +224,7 @@ func TestEventWebHandlers_NewEventForm(t *testing.T) {
 				</html>
 			`))
 
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			req := httptest.NewRequest("GET", "/events/new", nil)
 			ctx := auth.WithUser(req.Context(), tt.user)
@@ -350,7 +350,7 @@ func TestEventWebHandlers_EditEventForm(t *testing.T) {
 				</html>
 			`))
 
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			req := httptest.NewRequest("GET", "/events/"+tt.eventID+"/edit", nil)
 			rctx := chi.NewRouteContext()
@@ -476,7 +476,7 @@ func TestEventWebHandlers_GetEventPage(t *testing.T) {
 				</html>
 			`))
 
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			req := httptest.NewRequest("GET", "/events/"+tt.eventID, nil)
 			rctx := chi.NewRouteContext()
@@ -597,7 +597,7 @@ func TestEventWebHandlers_CreateEventFromForm(t *testing.T) {
 			}
 
 			tmpl := template.New("test")
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			req := httptest.NewRequest("POST", "/events", strings.NewReader(tt.formData.Encode()))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -751,7 +751,7 @@ func TestEventWebHandlers_UpdateEventFromForm(t *testing.T) {
 			}
 
 			tmpl := template.New("test")
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			req := httptest.NewRequest("POST", "/events/"+tt.eventID, strings.NewReader(tt.formData.Encode()))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -865,7 +865,7 @@ func TestEventWebHandlers_PublishEventAction(t *testing.T) {
 			}
 
 			tmpl := template.New("test")
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			formData := url.Values{
 				"csrf_token": []string{"test-csrf-token"},
@@ -1005,7 +1005,7 @@ func TestEventWebHandlers_CancelEventAction(t *testing.T) {
 			}
 
 			tmpl := template.New("test")
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			req := httptest.NewRequest("POST", "/events/"+tt.eventID+"/cancel", strings.NewReader(tt.formData.Encode()))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1119,7 +1119,7 @@ func TestEventWebHandlers_DeleteEventAction(t *testing.T) {
 			}
 
 			tmpl := template.New("test")
-			handlers := NewEventWebHandlers(mockService, nil, tmpl, tmpl, tmpl)
+			handlers := NewEventWebHandlers(mockService, nil, nil, tmpl, tmpl, tmpl)
 
 			formData := url.Values{
 				"csrf_token": []string{"test-csrf-token"},

--- a/internal/handlers/questions_form_test.go
+++ b/internal/handlers/questions_form_test.go
@@ -1,0 +1,106 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/lenaxia/tinyrsvp/internal/models"
+)
+
+func TestParseQuestionsFromForm(t *testing.T) {
+	form := url.Values{
+		"questions[0][text]":    {"Dietary restrictions?"},
+		"questions[0][type]":    {"text"},
+		"questions[0][required]": {"on"},
+		"questions[1][text]":    {"Meal choice?"},
+		"questions[1][type]":    {"single_choice"},
+		"questions[1][options]": {"Chicken\nBeef\nVegan"},
+	}
+
+	questions := parseQuestionsFromForm(form)
+
+	if len(questions) != 2 {
+		t.Fatalf("expected 2 questions, got %d", len(questions))
+	}
+
+	if questions[0].QuestionText != "Dietary restrictions?" {
+		t.Errorf("question[0] text = %q", questions[0].QuestionText)
+	}
+	if questions[0].QuestionType != models.QuestionTypeText {
+		t.Errorf("question[0] type = %q", questions[0].QuestionType)
+	}
+	if !questions[0].Required {
+		t.Error("question[0] should be required")
+	}
+
+	if questions[1].QuestionType != models.QuestionTypeSingleChoice {
+		t.Errorf("question[1] type = %q", questions[1].QuestionType)
+	}
+	if questions[1].Options == nil {
+		t.Fatal("question[1] options should be set")
+	}
+	opts, err := questions[1].ParseOptions()
+	if err != nil {
+		t.Fatalf("ParseOptions failed: %v", err)
+	}
+	if len(opts) != 3 || opts[0] != "Chicken" || opts[2] != "Vegan" {
+		t.Errorf("parsed options = %v", opts)
+	}
+}
+
+func TestParseQuestionsFromForm_IgnoresEmpty(t *testing.T) {
+	form := url.Values{
+		"questions[0][text]": {""},
+		"questions[0][type]": {"text"},
+	}
+	questions := parseQuestionsFromForm(form)
+	if len(questions) != 0 {
+		t.Errorf("expected no questions for empty text, got %d", len(questions))
+	}
+}
+
+func TestCreateEventFromForm_CreatesQuestions(t *testing.T) {
+	created := 0
+	qsvc := &mockQuestionService{
+		addQuestionFunc: func(ctx context.Context, q *models.PreferenceQuestion) error {
+			created++
+			if q.EventID == 0 {
+				t.Error("question EventID should be set from created event")
+			}
+			return nil
+		},
+	}
+
+	form := url.Values{
+		"title":                   {"Test Event"},
+		"description":             {"desc"},
+		"start_time":              {"2026-09-01T18:00"},
+		"timezone":                {"America/Los_Angeles"},
+		"questions[0][text]":      {"Question one?"},
+		"questions[0][type]":      {"text"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/events", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	h := &EventWebHandlers{
+		service: &mockEventService{
+			CreateEventFunc: func(ctx context.Context, event *models.Event) error {
+				event.ID = 42
+				event.Status = models.EventStatusDraft
+				return nil
+			},
+		},
+		questionService: qsvc,
+	}
+
+	w := httptest.NewRecorder()
+	h.CreateEventFromForm(w, req)
+
+	if created != 1 {
+		t.Errorf("expected 1 question created, got %d", created)
+	}
+}

--- a/internal/handlers/questions_sync_test.go
+++ b/internal/handlers/questions_sync_test.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/lenaxia/tinyrsvp/internal/models"
+)
+
+func TestSyncQuestions_UpdateExisting(t *testing.T) {
+	updated := false
+	deleted := false
+	qsvc := &mockQuestionService{
+		getQuestionsFunc: func(ctx context.Context, eventID int64) ([]*models.PreferenceQuestion, error) {
+			return []*models.PreferenceQuestion{
+				{ID: 10, EventID: eventID, QuestionText: "Old text", QuestionType: models.QuestionTypeText},
+			}, nil
+		},
+		updateQuestionFunc: func(ctx context.Context, q *models.PreferenceQuestion) error {
+			if q.ID == 10 && q.QuestionText == "Updated text" {
+				updated = true
+			}
+			return nil
+		},
+		deleteQuestionFunc: func(ctx context.Context, id int64) error {
+			deleted = true
+			return nil
+		},
+	}
+
+	h := &EventWebHandlers{questionService: qsvc}
+	submitted := []*models.PreferenceQuestion{
+		{ID: 10, QuestionText: "Updated text", QuestionType: models.QuestionTypeText},
+	}
+
+	if err := h.syncQuestions(context.Background(), 1, submitted); err != nil {
+		t.Fatalf("syncQuestions failed: %v", err)
+	}
+
+	if !updated {
+		t.Error("expected existing question to be updated")
+	}
+	if deleted {
+		t.Error("should not have deleted (question 10 was in submitted list)")
+	}
+}
+
+func TestSyncQuestions_DeleteRemoved(t *testing.T) {
+	deletedIDs := []int64{}
+	qsvc := &mockQuestionService{
+		getQuestionsFunc: func(ctx context.Context, eventID int64) ([]*models.PreferenceQuestion, error) {
+			return []*models.PreferenceQuestion{
+				{ID: 10, EventID: eventID, QuestionText: "Q1"},
+				{ID: 20, EventID: eventID, QuestionText: "Q2"},
+			}, nil
+		},
+		addQuestionFunc: func(ctx context.Context, q *models.PreferenceQuestion) error {
+			return nil
+		},
+		deleteQuestionFunc: func(ctx context.Context, id int64) error {
+			deletedIDs = append(deletedIDs, id)
+			return nil
+		},
+	}
+
+	h := &EventWebHandlers{questionService: qsvc}
+	submitted := []*models.PreferenceQuestion{
+		{ID: 10, QuestionText: "Q1"}, // Q2 (id=20) removed
+	}
+
+	if err := h.syncQuestions(context.Background(), 1, submitted); err != nil {
+		t.Fatalf("syncQuestions failed: %v", err)
+	}
+
+	if len(deletedIDs) != 1 || deletedIDs[0] != 20 {
+		t.Errorf("expected id=20 to be deleted, got %v", deletedIDs)
+	}
+}
+
+func TestSyncQuestions_ReorderByPosition(t *testing.T) {
+	var orders []int
+	qsvc := &mockQuestionService{
+		getQuestionsFunc: func(ctx context.Context, eventID int64) ([]*models.PreferenceQuestion, error) {
+			return []*models.PreferenceQuestion{
+				{ID: 10, QuestionText: "A", DisplayOrder: 0},
+				{ID: 20, QuestionText: "B", DisplayOrder: 1},
+			}, nil
+		},
+		updateQuestionFunc: func(ctx context.Context, q *models.PreferenceQuestion) error {
+			orders = append(orders, q.DisplayOrder)
+			return nil
+		},
+	}
+
+	h := &EventWebHandlers{questionService: qsvc}
+	submitted := []*models.PreferenceQuestion{
+		{ID: 20, QuestionText: "B"}, // now first
+		{ID: 10, QuestionText: "A"}, // now second
+	}
+
+	if err := h.syncQuestions(context.Background(), 1, submitted); err != nil {
+		t.Fatalf("syncQuestions failed: %v", err)
+	}
+
+	if len(orders) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(orders))
+	}
+	if orders[0] != 0 || orders[1] != 1 {
+		t.Errorf("expected display orders [0,1] for reordered questions, got %v", orders)
+	}
+}
+
+func TestUpdateEventFromForm_SkipsQuestionsForPublishedEvent(t *testing.T) {
+	addCalled := false
+	qsvc := &mockQuestionService{
+		addQuestionFunc: func(ctx context.Context, q *models.PreferenceQuestion) error {
+			addCalled = true
+			return nil
+		},
+	}
+
+	form := url.Values{
+		"title":              {"Updated"},
+		"version":            {"1"},
+		"questions[0][text]": {"Should be ignored"},
+		"questions[0][type]": {"text"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/events/1", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	mockSvc := &mockEventService{
+		GetEventFunc: func(ctx context.Context, id int64) (*models.Event, error) {
+			return &models.Event{
+				ID:     1,
+				Title:  "Test",
+				Status: models.EventStatusPublished,
+			}, nil
+		},
+		UpdateEventFunc: func(ctx context.Context, event *models.Event) error {
+			return nil
+		},
+	}
+
+	h := &EventWebHandlers{
+		service:         mockSvc,
+		questionService: qsvc,
+	}
+
+	w := httptest.NewRecorder()
+	h.UpdateEventFromForm(w, req)
+
+	if addCalled {
+		t.Error("should not call AddQuestion for a published event")
+	}
+}

--- a/static/js/questions.js
+++ b/static/js/questions.js
@@ -1,0 +1,88 @@
+(function() {
+    'use strict';
+
+    var container = document.getElementById('questions-container');
+    var addBtn = document.getElementById('add-question-btn');
+    if (!container || !addBtn) return;
+
+    function renumber() {
+        var items = container.querySelectorAll('.question-item');
+        items.forEach(function(item, index) {
+            item.dataset.index = index;
+            var label = item.querySelector('.form-label');
+            if (label) {
+                label.textContent = 'Question ' + (index + 1);
+            }
+            item.querySelectorAll('input, select, textarea').forEach(function(field) {
+                var name = field.getAttribute('name');
+                var id = field.getAttribute('id');
+                if (name) field.setAttribute('name', name.replace(/questions\[\d+\]/, 'questions[' + index + ']'));
+                if (id) field.setAttribute('id', id.replace(/question_\d+_/, 'question_' + index + '_'));
+            });
+            item.querySelector('.remove-question').dataset.index = index;
+        });
+    }
+
+    function toggleOptions(item) {
+        var type = item.querySelector('select[name$="[type]"]');
+        var optionsField = item.querySelector('.question-options-field');
+        if (!type || !optionsField) return;
+        optionsField.style.display = (type.value === 'single_choice' || type.value === 'multiple_choice') ? 'block' : 'none';
+    }
+
+    function createItem(index) {
+        var item = document.createElement('div');
+        item.className = 'question-item';
+        item.dataset.index = index;
+        item.innerHTML =
+            '<input type="hidden" name="questions[' + index + '][id]" value="">' +
+            '<div class="form-group">' +
+                '<label for="question_' + index + '_text" class="form-label">Question ' + (index + 1) + '</label>' +
+                '<input type="text" id="question_' + index + '_text" name="questions[' + index + '][text]" class="form-input" placeholder="e.g., Do you have any dietary restrictions?">' +
+            '</div>' +
+            '<div class="form-group">' +
+                '<label for="question_' + index + '_type" class="form-label">Answer Type</label>' +
+                '<select id="question_' + index + '_type" name="questions[' + index + '][type]" class="form-select">' +
+                    '<option value="text">Text</option>' +
+                    '<option value="single_choice">Single Choice</option>' +
+                    '<option value="multiple_choice">Multiple Choice</option>' +
+                '</select>' +
+            '</div>' +
+            '<div class="form-group question-options-field" style="display:none;">' +
+                '<label for="question_' + index + '_options" class="form-label">Options (one per line)</label>' +
+                '<textarea id="question_' + index + '_options" name="questions[' + index + '][options]" class="form-textarea" rows="3"></textarea>' +
+            '</div>' +
+            '<label class="form-checkbox-label">' +
+                '<input type="checkbox" name="questions[' + index + '][required]" class="form-checkbox">' +
+                '<span>Required</span>' +
+            '</label>' +
+            '<button type="button" class="btn btn-danger btn-sm remove-question" data-index="' + index + '">Remove</button>';
+
+        var typeSelect = item.querySelector('select[name$="[type]"]');
+        typeSelect.addEventListener('change', function() { toggleOptions(item); });
+
+        var removeBtn = item.querySelector('.remove-question');
+        removeBtn.addEventListener('click', function() {
+            item.parentNode.removeChild(item);
+            renumber();
+        });
+
+        return item;
+    }
+
+    container.querySelectorAll('.question-item').forEach(function(item) {
+        var typeSelect = item.querySelector('select[name$="[type]"]');
+        if (typeSelect) typeSelect.addEventListener('change', function() { toggleOptions(item); });
+        var removeBtn = item.querySelector('.remove-question');
+        if (removeBtn) removeBtn.addEventListener('click', function() {
+            item.parentNode.removeChild(item);
+            renumber();
+        });
+        toggleOptions(item);
+    });
+
+    addBtn.addEventListener('click', function() {
+        var index = container.querySelectorAll('.question-item').length;
+        container.appendChild(createItem(index));
+    });
+})();

--- a/templates/web/event_form.html
+++ b/templates/web/event_form.html
@@ -185,24 +185,10 @@
                     <h2 class="form-section-title">Preference Questions</h2>
                     <p class="form-help-text">Ask guests about dietary restrictions, meal preferences, etc.</p>
 
-                    {{/* Coming-soon overlay */}}
-                    <div style="
-                        position:absolute;inset:0;
-                        background:rgba(var(--color-background-rgb,249,250,251),0.85);
-                        border-radius:var(--border-radius-lg,0.5rem);
-                        display:flex;flex-direction:column;
-                        align-items:center;justify-content:center;
-                        gap:0.5rem;z-index:10;
-                        border:2px dashed var(--color-border,#e5e7eb);
-                    ">
-                        <span style="font-size:2rem">🚧</span>
-                        <strong>Coming Soon</strong>
-                        <span style="color:var(--color-text-secondary,#666);font-size:0.875rem">Preference questions will be available in a future release.</span>
-                    </div>
-
-                    <div id="questions-container" aria-hidden="true">
+                    <div id="questions-container">
                         {{range $index, $question := .Questions}}
                         <div class="question-item" data-index="{{$index}}">
+                            <input type="hidden" name="questions[{{$index}}][id]" value="{{$question.ID}}">
                             <div class="form-group">
                                 <label for="question_{{$index}}_text" class="form-label">Question {{add $index 1}}</label>
                                 <input
@@ -212,7 +198,6 @@
                                     class="form-input"
                                     value="{{$question.Text}}"
                                     placeholder="e.g., Do you have any dietary restrictions?"
-                                    disabled
                                 >
                             </div>
                             <div class="form-group">
@@ -221,20 +206,39 @@
                                     id="question_{{$index}}_type"
                                     name="questions[{{$index}}][type]"
                                     class="form-select"
-                                    disabled
                                 >
-                                    <option value="text"{{if eq $question.Type "text"}} selected{{end}}>Text</option>
-                                    <option value="choice"{{if eq $question.Type "choice"}} selected{{end}}>Multiple Choice</option>
+                                    <option value="text"{{if eq $question.QuestionType "text"}} selected{{end}}>Text</option>
+                                    <option value="single_choice"{{if eq $question.QuestionType "single_choice"}} selected{{end}}>Single Choice</option>
+                                    <option value="multiple_choice"{{if eq $question.QuestionType "multiple_choice"}} selected{{end}}>Multiple Choice</option>
                                 </select>
                             </div>
-                            <button type="button" class="btn btn-danger btn-sm remove-question" data-index="{{$index}}" disabled>
+                            <div class="form-group question-options-field" style="display: {{if or (eq $question.QuestionType "single_choice") (eq $question.QuestionType "multiple_choice")}}block{{else}}none{{end}};">
+                                <label for="question_{{$index}}_options" class="form-label">Options (one per line)</label>
+                                <textarea
+                                    id="question_{{$index}}_options"
+                                    name="questions[{{$index}}][options]"
+                                    class="form-textarea"
+                                    rows="3"
+                                >{{if $question.Options}}{{range $question.ParseOptions}}{{.}}
+{{end}}{{end}}</textarea>
+                            </div>
+                            <label class="form-checkbox-label">
+                                <input
+                                    type="checkbox"
+                                    name="questions[{{$index}}][required]"
+                                    class="form-checkbox"
+                                    {{if $question.Required}}checked{{end}}
+                                >
+                                <span>Required</span>
+                            </label>
+                            <button type="button" class="btn btn-danger btn-sm remove-question" data-index="{{$index}}">
                                 Remove
                             </button>
                         </div>
                         {{end}}
                     </div>
 
-                    <button type="button" class="btn btn-secondary" id="add-question-btn" disabled>
+                    <button type="button" class="btn btn-secondary" id="add-question-btn">
                         Add Question
                     </button>
                 </section>
@@ -293,4 +297,5 @@
     <script src="/static/js/theme_preview_modal.js"></script>
     <script src="/static/js/image_upload.js"></script>
     <script src="/static/js/color_picker.js"></script>
+    <script src="/static/js/questions.js"></script>
 {{end}}

--- a/tests/uxserver/server.go
+++ b/tests/uxserver/server.go
@@ -312,7 +312,7 @@ func Setup(opts Options) (*Server, func(), error) {
 		filepath.Join(templateBase, "event_detail.html"),
 	)
 
-	eventWebHandlers := handlers.NewEventWebHandlers(eventService, templateService, eventListTemplates, eventFormTemplates, eventDetailTemplates)
+	eventWebHandlers := handlers.NewEventWebHandlers(eventService, templateService, questionService, eventListTemplates, eventFormTemplates, eventDetailTemplates)
 
 	customizationTemplates := mustParse("event_customization.html", funcMap,
 		filepath.Join(templateBase, "partials/base.html"),


### PR DESCRIPTION
## Summary

The preference-questions backend (table, repo, service, API) was complete, but the event form gated it behind a 🚧 'Coming Soon' overlay with disabled inputs. This wires the UI end-to-end. Closes #11.

## Changes
- `EventWebHandlers` now takes a `QuestionService`. `EditEventForm` loads existing questions; `CreateEventFromForm` creates submitted questions after the event; `UpdateEventFromForm` syncs the question list (create/update/delete/reorder) for draft events (matching the service rule that published events can't be modified).
- `parseQuestionsFromForm` extracts `questions[N][id|text|type|required|options]` fields; options are one-per-line.
- Removed the overlay, enabled the fields, fixed the answer-type enum values (`text`/`single_choice`/`multiple_choice`), added id/required/options inputs.
- New `static/js/questions.js` for add/remove rows + options show/hide.

## Tests
- New `questions_form_test.go` (parse helper + create flow with event ID propagation).
- All 39 non-browser packages pass; build/vet clean.