### PR TITLE
feat: enforce PrivateGuestList — hide attendance stats from non-owners

### DIFF
--- a/docs/01_WORKLOG/0186_2026-08-01_private_guest_list_enforcement.md
+++ b/docs/01_WORKLOG/0186_2026-08-01_private_guest_list_enforcement.md
@@ -1,0 +1,19 @@
+# Worklog: Enforce PrivateGuestList
+
+**Date:** 2026-08-01  
+**PR:** #74
+
+## Summary
+
+The `PrivateGuestList` flag was stored in the DB and shown as a UI checkbox but had zero behavioral effect. This PR enforces it by hiding attendance stats (InviteCount/RSVPCount/AcceptCount) on the event list for private events when the viewer is not the owner or admin.
+
+## Changes
+- Added `hidePrivateGuestListStats` helper that zeroes stats on private events for non-owners/non-admins.
+- Applied in the web `ListEventsPage` handler (the only place stats are exposed cross-user).
+- Template shows a lock icon + "Guest list is private" instead of raw counts.
+- Added `CurrentUserID` to `EventListPageData`.
+- The API `ListEvents` handler was already safe (returns no stats).
+- 4 unit tests: non-owner hidden, owner sees stats, admin sees stats, non-private never hidden.
+
+## Status
+✅ Complete — all 39 non-browser packages pass.

--- a/internal/handlers/events_web.go
+++ b/internal/handlers/events_web.go
@@ -30,16 +30,17 @@ type EventWebHandlers struct {
 }
 
 type EventListPageData struct {
-	ActivePage string
-	IsAdmin    bool
-	Events     []*models.EventWithStats
-	Total      int
-	Page       int
-	PageSize   int
-	Filter     string
-	Sort       string
-	Error      string
-	Loading    bool
+	ActivePage   string
+	IsAdmin      bool
+	CurrentUserID int64
+	Events       []*models.EventWithStats
+	Total        int
+	Page         int
+	PageSize     int
+	Filter       string
+	Sort         string
+	Error        string
+	Loading      bool
 }
 
 type EventFormPageData struct {
@@ -121,6 +122,8 @@ func (h *EventWebHandlers) ListEventsPage(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	hidePrivateGuestListStats(eventList, user)
+
 	total, err := h.service.CountEvents(r.Context(), filters)
 	if err != nil {
 		HandleError(w, r, err)
@@ -128,9 +131,10 @@ func (h *EventWebHandlers) ListEventsPage(w http.ResponseWriter, r *http.Request
 	}
 
 	data := &EventListPageData{
-		ActivePage: "events",
-		IsAdmin:    isAdminRequest(r),
-		Events:     eventList,
+		ActivePage:   "events",
+		IsAdmin:      isAdminRequest(r),
+		CurrentUserID: user.ID,
+		Events:       eventList,
 		Total:      total,
 		Page:       page,
 		PageSize:   limit,
@@ -759,4 +763,21 @@ func parseQuestionsFromForm(form url.Values) []*models.PreferenceQuestion {
 	}
 
 	return questions
+}
+
+// hidePrivateGuestListStats zeroes the InviteCount/RSVPCount/AcceptCount on
+// events marked PrivateGuestList=true when the viewer is not the event owner
+// or an admin. The event itself is still visible; only attendance figures are
+// hidden.
+func hidePrivateGuestListStats(events []*models.EventWithStats, user *models.User) {
+	if user == nil || user.IsAdmin() {
+		return
+	}
+	for _, e := range events {
+		if e.PrivateGuestList && e.CreatedBy != user.ID {
+			e.InviteCount = 0
+			e.RSVPCount = 0
+			e.AcceptCount = 0
+		}
+	}
 }

--- a/internal/handlers/private_guest_list_test.go
+++ b/internal/handlers/private_guest_list_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/lenaxia/tinyrsvp/internal/models"
+)
+
+func TestHidePrivateGuestListStats(t *testing.T) {
+	tests := []struct {
+		name           string
+		events         []*models.EventWithStats
+		user           *models.User
+		wantHidden     []bool
+	}{
+		{
+			name: "non-owner sees zeros for private event",
+			events: []*models.EventWithStats{
+				{Event: models.Event{ID: 1, CreatedBy: 10, PrivateGuestList: true}, InviteCount: 5, RSVPCount: 3, AcceptCount: 2},
+				{Event: models.Event{ID: 2, CreatedBy: 20, PrivateGuestList: false}, InviteCount: 8, RSVPCount: 6, AcceptCount: 4},
+			},
+			user:       &models.User{ID: 20, Role: models.RoleEventManager},
+			wantHidden: []bool{true, false},
+		},
+		{
+			name: "owner sees full stats for own private event",
+			events: []*models.EventWithStats{
+				{Event: models.Event{ID: 1, CreatedBy: 10, PrivateGuestList: true}, InviteCount: 5, RSVPCount: 3, AcceptCount: 2},
+			},
+			user:       &models.User{ID: 10, Role: models.RoleEventManager},
+			wantHidden: []bool{false},
+		},
+		{
+			name: "admin sees full stats even for private events",
+			events: []*models.EventWithStats{
+				{Event: models.Event{ID: 1, CreatedBy: 10, PrivateGuestList: true}, InviteCount: 5, RSVPCount: 3, AcceptCount: 2},
+			},
+			user:       &models.User{ID: 99, Role: models.RoleAdmin},
+			wantHidden: []bool{false},
+		},
+		{
+			name: "non-private events are never hidden",
+			events: []*models.EventWithStats{
+				{Event: models.Event{ID: 1, CreatedBy: 10, PrivateGuestList: false}, InviteCount: 5, RSVPCount: 3, AcceptCount: 2},
+			},
+			user:       &models.User{ID: 20, Role: models.RoleEventManager},
+			wantHidden: []bool{false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hidePrivateGuestListStats(tt.events, tt.user)
+
+			for i, e := range tt.events {
+				hidden := e.InviteCount == 0 && e.RSVPCount == 0 && e.AcceptCount == 0
+				if hidden != tt.wantHidden[i] {
+					t.Errorf("event[%d]: stats hidden=%v, want %v (Invite=%d RSVP=%d Accept=%d)",
+						i, hidden, tt.wantHidden[i], e.InviteCount, e.RSVPCount, e.AcceptCount)
+				}
+			}
+		})
+	}
+}

--- a/templates/web/event_list.html
+++ b/templates/web/event_list.html
@@ -105,6 +105,14 @@
                     </div>
                 </div>
 
+                {{if and .PrivateGuestList (not $.IsAdmin) (ne .CreatedBy $.CurrentUserID)}}
+                <div class="event-card-stats" role="list">
+                    <span class="event-card-stat" role="listitem">
+                        <span class="event-card-meta-icon" aria-hidden="true">🔒</span>
+                        <span>Guest list is private</span>
+                    </span>
+                </div>
+                {{else}}
                 <div class="event-card-stats" role="list">
                     <span class="event-card-stat" role="listitem">
                         <span class="event-card-meta-icon" aria-hidden="true">✉️</span>
@@ -122,6 +130,7 @@
                         <span>Accepted</span>
                     </span>
                 </div>
+                {{end}}
             </div>
 
             <footer class="event-card-footer">

--- a/templates/web/event_list_test.go
+++ b/templates/web/event_list_test.go
@@ -8,26 +8,30 @@ import (
 )
 
 type EventListEvent struct {
-	ID          int
-	Title       string
-	Description string
-	Location    string
-	StartTime   time.Time
-	Status      string
-	InviteCount int
-	RSVPCount   int
-	AcceptCount int
+	ID               int
+	Title            string
+	Description      string
+	Location         string
+	StartTime        time.Time
+	Status           string
+	InviteCount      int
+	RSVPCount        int
+	AcceptCount      int
+	PrivateGuestList bool
+	CreatedBy        int64
 }
 
 type EventListData struct {
-	Events  []EventListEvent
-	Loading bool
-	Error   string
-	Filter  string
-	Sort    string
-	Page    int
-	Total   int
-	PageSize int
+	Events       []EventListEvent
+	Loading      bool
+	Error        string
+	Filter       string
+	Sort         string
+	Page         int
+	Total        int
+	PageSize     int
+	IsAdmin      bool
+	CurrentUserID int64
 }
 
 func getEventListTemplate() (*template.Template, error) {


### PR DESCRIPTION
## Summary

The `PrivateGuestList` flag was stored in the DB and shown as a UI checkbox but had zero behavioral effect. This PR enforces it.

## Changes
- The event list handler zeroes `InviteCount`/`RSVPCount`/`AcceptCount` on private events when the viewer is not the event owner or an admin.
- The event list template shows a lock icon + 'Guest list is private' instead of the raw counts for those events.
- Owners and admins always see full stats.
- The API `ListEvents` handler was already safe (returns no stats).
- Added `CurrentUserID` to `EventListPageData` so the template can compare against `CreatedBy`.
- Added 4 unit tests covering: non-owner hidden, owner sees stats, admin sees stats, non-private never hidden.

## Verification
All 39 non-browser packages pass; build/vet clean.