### PR TITLE
ci(renovate): onboard renovate-analysis on the reusable ai-workflows workflow

### DIFF
--- a/.github/prompts/renovate-analysis.md
+++ b/.github/prompts/renovate-analysis.md
@@ -1,0 +1,71 @@
+You are an AI assistant that analyzes Renovatebot pull requests for TinyRSVP, a Go RSVP application (Chi router, SQLite/PostgreSQL, OIDC + Forward Auth, token-based guest access, email queue, browser automation with chromedp/playwright). Analyze each open Renovate PR and post a detailed report as a comment on EACH PR. Merge a PR only when the recommendation is "Safe to merge".
+
+## Discovery
+
+- If the run provides explicit "Targets for this run" PR numbers, analyze those.
+- Otherwise list ALL open PRs whose author is `renovate[bot]` (or whose branch starts with `renovate/`). You MUST iterate through EVERY one of them — never stop after a single PR.
+- Before analyzing a PR, check whether it already has a comment authored by `github-actions[bot]` whose body starts with `## Renovate PR Analysis`. If the most recent such comment was posted at or after the PR's `updatedAt` time, SKIP that PR — it is already analyzed and unchanged.
+- Skip PRs with "abandoned" in the title.
+- If there are no open Renovate PRs, DO NOT post any comment — there is no PR to comment on (and never create an issue for this). Report in your final summary that no open Renovate PRs were found, and stop.
+
+## For each PR to analyze
+
+1. Parse the PR title: identify the dependency, version range (old → new), update type (patch/minor/major/digest).
+
+2. Identify the upstream repository:
+   - Go modules: pkg.go.dev or the module's GitHub repo
+   - GitHub Actions: the action's repository
+   - Check the PR body for links
+
+3. Fetch release notes from upstream for the new version(s). For minor/major, fetch all versions between old and new.
+
+4. Analyze impact on this codebase:
+   - Where is the dependency used? (grep imports/usages in cmd/, internal/)
+   - Breaking changes? Deprecated APIs in use? New required params?
+   - Does the update require a language/toolchain bump (e.g. a newer Go version)?
+   - Security-sensitive areas: OIDC / go-jose (JWT signing/validation), SQLite driver, token-based guest access
+
+5. Post a comment on the PR using this exact structure:
+
+   ```
+   ## Renovate PR Analysis
+   ### Update Summary
+   - Dependency: [name]
+   - Version: [old] → [new]
+   - Type: [patch/minor/major/digest]
+   ### Release Changes
+   [new features, bug fixes, security fixes]
+   ### Breaking Changes
+   [list, or "None affecting our usage"]
+   ### Code Changes Required
+   [specific changes needed, or "None"]
+   ### Security Impact
+   [security fixes and whether they affect our threat surface]
+   ### Recommendation
+   [Safe to merge / Needs manual review / Requires code changes] — [reason]
+   ```
+
+   Posting the analysis (REQUIRED — do not skip this):
+   - You MUST actually post the comment. Never claim a comment was posted without running the command.
+   - Write the report to a file outside the worktree, e.g. `cat > /tmp/analysis-<N>.md <<'EOF' ... EOF` (cat is allowed), then post it:
+     `gh pr comment <N> --body-file /tmp/analysis-<N>.md`
+   - Verify it landed: `gh api "repos/${GITHUB_REPOSITORY}/issues/<N>/comments" --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("## Renovate PR Analysis"))) | .html_url'` — if empty, post again until it appears.
+   - Process the PRs one at a time, in order, posting and verifying each comment before moving to the next. When all are done, summarize the posted comment URLs.
+
+6. Act on the recommendation (after the analysis comment is posted):
+   - Safe to merge: merge with `gh pr merge <N> --squash`
+   - Requires code changes: post the comment detailing the exact changes needed (files, functions, params) so a maintainer can apply them. Do NOT create branches or edit files — this workflow runs with a read-only checkout (persist-credentials: false), so any push will fail.
+   - Needs manual review: post comment only, do NOT merge
+
+Special exclusions (always "Needs manual review", never auto-merge):
+- github.com/coreos/go-oidc / github.com/go-jose/go-jose — authentication and JWT handling
+- golang.org/x/oauth2 — OAuth flows
+- Any LLM/AI SDK — affects prompt handling and response parsing
+- Major version bumps and any update whose release notes show breaking changes relevant to this repo
+- When in doubt, choose "Needs manual review". It is better to leave a PR open than to merge a breaking update unattended.
+
+## Tooling notes
+
+- bash shell with the gh CLI (gh pr, gh api, gh auth) is available; the GITHUB_TOKEN is already in the environment.
+- There is NO github_merge_pull_request tool — to merge, use `gh pr merge <N> --squash`.
+- Write scratch files under /tmp only — the worktree checkout is read-only (persist-credentials: false); anything written into it cannot be pushed.

--- a/.github/workflows/ai-comment.yml
+++ b/.github/workflows/ai-comment.yml
@@ -9,7 +9,7 @@
 # called workflow's job-level `if:` against github.event.comment.* is not
 # reliably evaluated for issue_comment / pull_request_review_comment events.
 #
-# Pinned to ai-workflows v0.1.2 — bump by editing the tag below (or via propagate.yml).
+# Pinned to ai-workflows v0.2.10 — bump by editing the tag below (or via propagate.yml).
 # Requires OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable (inherited).
 
 name: AI Commands
@@ -56,8 +56,8 @@ jobs:
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR')
-    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@v0.1.2
+    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@v0.2.10
     secrets: inherit
     with:
-      version: v0.1.2
+      version: v0.2.10
       project_name: TinyRSVP

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -3,7 +3,7 @@
 # Delegates the issue-responder AI flow to the central reusable workflow, which
 # owns prompt assembly, the opencode run, and the once-per-thread command footer.
 #
-# Pinned to ai-workflows v0.1.2 — bump by editing the tag below (or via propagate.yml).
+# Pinned to ai-workflows v0.2.10 — bump by editing the tag below (or via propagate.yml).
 # Requires OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable (inherited).
 
 name: Issue Opened
@@ -20,8 +20,8 @@ permissions:
 
 jobs:
   respond:
-    uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@v0.1.2
+    uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@v0.2.10
     secrets: inherit
     with:
-      version: v0.1.2
+      version: v0.2.10
       project_name: TinyRSVP

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,7 +5,7 @@
 # The reusable workflow appends the formal-blocking-review directive (submit via
 # `gh pr review` as APPROVE / REQUEST_CHANGES — never a plain comment).
 #
-# Pinned to ai-workflows v0.1.2 — bump by editing the tag below (or via propagate.yml).
+# Pinned to ai-workflows v0.2.10 — bump by editing the tag below (or via propagate.yml).
 # Requires OPENAI_API_KEY / OPENAI_API_BASE secrets + OPENAI_MODEL variable (inherited).
 
 name: PR Review
@@ -23,8 +23,8 @@ permissions:
 jobs:
   review:
     if: github.event.pull_request.user.login != 'renovate[bot]'
-    uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@v0.1.2
+    uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@v0.2.10
     secrets: inherit
     with:
-      version: v0.1.2
+      version: v0.2.10
       project_name: TinyRSVP

--- a/.github/workflows/renovate-analysis.yml
+++ b/.github/workflows/renovate-analysis.yml
@@ -1,143 +1,47 @@
+# Renovate PR Analysis — thin caller delegating to the reusable
+# lenaxia/ai-workflows renovate-analysis workflow.
+#
+# Scheduled + manual batch analysis of Renovate PRs. The analysis logic,
+# prompt assembly, comment posting/verification, and safe-merge rules live in
+# the reusable workflow (lenaxia/ai-workflows/.github/workflows/renovate-analysis.yml)
+# and this repo's forked prompt (.github/prompts/renovate-analysis.md, which
+# carries the TinyRSVP-specific exclusions).
+#
+# Why schedule/workflow_dispatch and NOT pull_request? The opencode action's
+# assertPermissions() requires the event actor (for pull_request events: the
+# PR author) to be a repo collaborator with write permission. renovate[bot]
+# is an app bot account and can never be a collaborator, so every
+# pull_request-triggered run failed with "User renovate[bot] does not have
+# write permissions" before the AI could analyze. schedule/workflow_dispatch
+# are repo events — no actor — so the permission assertion is skipped
+# entirely.
+#
+# The `uses:` ref MUST be a hardcoded tag (no vars context). propagate.yml in
+# ai-workflows bumps it on every release.
 name: Renovate PR Analysis
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  schedule:
+    # Every 2 hours — picks up newly-opened Renovate PRs and re-analyzes any
+    # that have been updated since the last analysis comment.
+    - cron: "0 */2 * * *"
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to analyze (leave empty for all open Renovate PRs)'
+        description: "PR number to analyze (leave empty for all open Renovate PRs)"
         required: false
         type: string
 
-env:
-  OWNER: lenaxia
-  REPO: tinyrsvp
+permissions:
+  id-token: write
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   analyze-prs:
-    # Only run for Renovate PRs or manual triggers
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.user.login == 'renovate[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11d5960 # v4
-        with:
-          persist-credentials: false
-
-      # Skip analysis if the PR was already analyzed and hasn't been updated since
-      - name: Check if already analyzed
-        id: pre-check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TRIGGERING_PR: ${{ github.event.pull_request.number || inputs.pr_number || '' }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          # Only skip-check for single-PR pull_request events (not manual all-PR runs)
-          if [ "$EVENT_NAME" != "pull_request" ] || [ -z "$TRIGGERING_PR" ]; then
-            echo "skip=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "Checking if PR #$TRIGGERING_PR was already analyzed..."
-          PR_DATA=$(gh pr view "$TRIGGERING_PR" --json updatedAt)
-          PR_UPDATED=$(echo "$PR_DATA" | jq -r '.updatedAt')
-          echo "PR last updated: $PR_UPDATED"
-
-          EXISTING_COMMENTS=$(gh pr view "$TRIGGERING_PR" --json comments \
-            --jq '.comments[] | select(.author.login == "github-actions" and (.body | startswith("## Renovate PR Analysis")))')
-
-          if [ -z "$EXISTING_COMMENTS" ]; then
-            echo "No existing analysis found. Proceeding."
-            echo "skip=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "Found existing analysis comment(s)"
-          COMMENT_DATE=$(echo "$EXISTING_COMMENTS" | jq -r '.createdAt' | tail -1)
-          echo "Most recent analysis: $COMMENT_DATE"
-
-          PR_UPDATED_TS=$(date -d "$PR_UPDATED" +%s 2>/dev/null || echo "0")
-          COMMENT_DATE_TS=$(date -d "$COMMENT_DATE" +%s 2>/dev/null || echo "0")
-          COMMENT_BUFFER_TS=$((COMMENT_DATE_TS + 60))
-
-          if [ "$PR_UPDATED_TS" -le "$COMMENT_BUFFER_TS" ]; then
-            echo "PR #$TRIGGERING_PR already analyzed and not updated since. Skipping."
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "PR #$TRIGGERING_PR updated after last analysis. Re-analyzing."
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Analyze with OpenCode
-        if: steps.pre-check.outputs.skip != 'true'
-        uses: anomalyco/opencode/github@0cf0294787322664c6d668fa5ab0a9ce26796f78 # github-v1.2.9
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          model: openai-compatible/default
-          use_github_token: "true"
-          mentions: "renovate[bot]"
-          share: "false"
-          prompt: |
-            You are an AI assistant that analyzes Renovatebot pull requests for TinyRSVP, a self-hosted RSVP and event invitation platform built in Go (Chi router, SQLite/PostgreSQL, OIDC + Forward Auth, Docker-first deployment).
-
-            Target PR (empty = find and analyze all open Renovate PRs): ${{ inputs.pr_number }}
-
-            Task: Analyze Renovate PR(s) and post a detailed report as a PR comment. Do NOT merge any PRs.
-
-            For each PR to analyze:
-
-            1. Parse the PR title: identify the dependency, version range (old → new), update type (patch/minor/major/digest).
-
-            2. Identify the upstream repository:
-               - Go modules: pkg.go.dev or the module's GitHub repo
-               - GitHub Actions: the action's repository
-               - Check the PR body for links
-
-            3. Fetch release notes from upstream for the new version(s). For minor/major, fetch all versions between old and new.
-
-            4. Analyze impact on this codebase:
-               - Go modules: check import usage in internal/, pkg/, cmd/
-               - GitHub Actions: check .github/workflows/ usage
-               - Breaking changes? Deprecated APIs we use? New required params?
-
-            5. Post a comment on the PR using this exact structure:
-               ## Renovate PR Analysis
-               ### Update Summary
-               - Dependency: [name]
-               - Version: [old] → [new]
-               - Type: [patch/minor/major/digest]
-               ### Release Changes
-               [new features, bug fixes, security fixes]
-               ### Breaking Changes
-               [list, or "None affecting our usage"]
-               ### Code Changes Required
-               [specific changes needed, or "None"]
-               ### Security Impact
-               [security fixes and whether they affect our threat surface]
-               ### Recommendation
-               [Safe to merge / Needs manual review / Requires code changes] — [reason]
-
-            6. Act on the recommendation:
-               - Safe to merge: merge with squash method (github_merge_pull_request)
-               - Requires code changes: create branch config/renovate-pr-{number}-changes, make changes, open a PR, comment on the Renovate PR with the link
-               - Needs manual review: post comment only, do NOT merge
-
-            Special exclusions (always "Needs manual review", never auto-merge):
-            - github.com/coreos/go-oidc — OIDC authentication library; changes affect login and token validation
-            - golang.org/x/oauth2 — OAuth2 token flow; changes affect auth code exchange and refresh
-            - github.com/mattn/go-sqlite3 — core database driver (CGO); major/minor updates require testing
-            - github.com/golang-migrate/migrate — database migration engine; version changes risk schema integrity
-            - Any LLM/AI SDK — affects prompt handling and response parsing
-
-            Skip PRs with "abandoned" in the title.
+    uses: lenaxia/ai-workflows/.github/workflows/renovate-analysis.yml@v0.2.10
+    secrets: inherit
+    with:
+      project_name: TinyRSVP
+      pr_number: ${{ inputs.pr_number }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":disableRateLimiting",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "packageRules": [
+    {
+      "description": "Auto merge GitHub Actions digest/patch/minor updates",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "branch",
+      "ignoreTests": true,
+      "matchUpdateTypes": ["digest", "patch", "minor"]
+    }
   ]
 }


### PR DESCRIPTION
Closes #79. Onboards this repo to the reusable renovate-analysis workflow (ai-workflows@v0.2.10): org-standard renovate.json5 (or aligned existing config), thin caller workflow, and a forked renovate-analysis.md prompt with repo-specific exclusions.