### PR TITLE
ci(renovate): exclude lenaxia/ai-workflows pins from Renovate (propagate-only)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,12 @@
   ],
   "packageRules": [
     {
+      "description": "ai-workflows pins are bumped by propagate.yml syncs only",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["lenaxia/ai-workflows"],
+      "enabled": false
+    },
+    {
       "description": "Auto merge GitHub Actions digest/patch/minor updates",
       "matchManagers": ["github-actions"],
       "automerge": true,


### PR DESCRIPTION
## What

One new first `packageRule` in `renovate.json`: disable Renovate entirely for `lenaxia/ai-workflows` (`enabled: false`, exact `matchPackageNames`).

## Why

The existing GitHub-Actions automerge rule (`automergeType: 'branch'`, digest/patch/minor) treats the sibling callers' `uses: lenaxia/ai-workflows/...@v0.2.10` pins as managed deps. On the next ai-workflows tag it would land the bump **directly on main with no PR**, rewriting only the `uses:` ref — Renovate never updates `with:` inputs (only its built-in community `uses-with` table gets that). The sibling callers' `version: v0.2.10` input (the checkout ref for scripts/prompts) would be stranded, and propagate.yml's `s|version: OLD_TAG|version: NEW_TAG|g` repair sed can never match again (it derives `OLD_TAG` from the already-bumped `uses:` line).

This is not theoretical: **talos-ops-prod main got stranded exactly this way today** (`22e5abac` bumped `uses:` to v0.2.10 via branch automerge, `version:` stayed v0.2.9 — fixed in talos-ops-prod#2286).

`enabled: false` rather than `automerge: false`: even a human-merged Renovate PR for these pins would bump `uses:` without `version:` and re-strand. Pins move via propagate.yml lockstep syncs only. Org-wide tracking: ai-workflows#39.

## Verification

- `renovate.json` parses as valid JSON (2 packageRules).
- No other changes.